### PR TITLE
Fix `ValueError: high is out of bounds for int32` in `randint` Calls

### DIFF
--- a/src/tabpfn_extensions/hpo/tuned_tabpfn.py
+++ b/src/tabpfn_extensions/hpo/tuned_tabpfn.py
@@ -87,8 +87,8 @@ class TunedTabPFNBase(BaseEstimator):
         rng = check_random_state(self.random_state)
 
         # Set random seeds for reproducibility
-        torch.manual_seed(rng.randint(0, 2**32 - 1))
-        np.random.seed(rng.randint(0, 2**32 - 1))
+        torch.manual_seed(rng.randint(0, 2**32 - 1,dtype=np.int64))
+        np.random.seed(rng.randint(0, 2**32 - 1,dtype=np.int64))
 
         # Fit transformers
         X = self._cat_encoder.fit_transform(X)
@@ -100,7 +100,7 @@ class TunedTabPFNBase(BaseEstimator):
             X,
             y,
             test_size=self.n_validation_size,
-            random_state=rng.randint(0, 2**32 - 1),
+            random_state=rng.randint(0, 2**32 - 1,dtype=np.int64),
             stratify=y if task_type == "multiclass" else None,
         )
 
@@ -121,7 +121,7 @@ class TunedTabPFNBase(BaseEstimator):
             }
             model_params["inference_config"] = inference_config
             model_params["device"] = self.device
-            model_params["random_state"] = rng.randint(0, 2**32 - 1)
+            model_params["random_state"] = rng.randint(0, 2**32 - 1,dtype=np.int64)
 
             # Handle special parameters
             n_ensemble_repeats = model_params.pop("n_ensemble_repeats", None)
@@ -198,12 +198,12 @@ class TunedTabPFNBase(BaseEstimator):
             if task_type in ["binary", "multiclass"]:
                 self.best_model_ = TabPFNClassifier(
                     device=self.device,
-                    random_state=rng.randint(0, 2**32 - 1),
+                    random_state=rng.randint(0, 2**32 - 1,dtype=np.int64),
                 )
             else:
                 self.best_model_ = TabPFNRegressor(
                     device=self.device,
-                    random_state=rng.randint(0, 2**32 - 1),
+                    random_state=rng.randint(0, 2**32 - 1,dtype=np.int64),
                 )
             self.best_model_.fit(X, y)
 

--- a/src/tabpfn_extensions/post_hoc_ensembles/abstract_validation_utils.py
+++ b/src/tabpfn_extensions/post_hoc_ensembles/abstract_validation_utils.py
@@ -69,7 +69,7 @@ class AbstractValidationUtils(ABC, BaseEstimator):
         self._start_time: int = 0
         self.classes_: np.ndarray | None = None
         self._repeats_seed = [
-            int(self._rng.randint(0, 2**32)) for _ in range(self.n_repeats)
+            int(self._rng.randint(0, 2**32,dtype=np.int64)) for _ in range(self.n_repeats)
         ]
         self._estimators = estimators.copy()  # internal copy for early stopping.
         self.validation_method = validation_method

--- a/src/tabpfn_extensions/post_hoc_ensembles/sklearn_interface.py
+++ b/src/tabpfn_extensions/post_hoc_ensembles/sklearn_interface.py
@@ -84,9 +84,9 @@ class AutoTabPFNClassifier(ClassifierMixin, BaseEstimator):
         rnd = check_random_state(self.random_state)
 
         # Torch reproducibility bomb
-        torch.manual_seed(rnd.randint(0, 2**32 - 1))
-        random.seed(rnd.randint(0, 2**32 - 1))
-        np.random.seed(rnd.randint(0, 2**32 - 1))  # noqa: NPY002
+        torch.manual_seed(rnd.randint(0, 2**32 - 1, dtype=np.int64))
+        random.seed(rnd.randint(0, 2**32 - 1, dtype=np.int64))
+        np.random.seed(rnd.randint(0, 2**32 - 1, dtype=np.int64))  # noqa: NPY002
 
         task_type = (
             TaskType.MULTICLASS if len(unique_labels(y)) > 2 else TaskType.BINARY
@@ -97,8 +97,8 @@ class AutoTabPFNClassifier(ClassifierMixin, BaseEstimator):
             max_time=self.max_time,
             ges_scoring_string=self.ges_scoring_string,
             device=self.device,
-            bm_random_state=rnd.randint(0, 2**32 - 1),
-            ges_random_state=rnd.randint(0, 2**32 - 1),
+            bm_random_state=rnd.randint(0, 2**32 - 1, dtype=np.int64),
+            ges_random_state=rnd.randint(0, 2**32 - 1, dtype=np.int64),
             **self.phe_init_args_,
         )
 
@@ -192,9 +192,9 @@ class AutoTabPFNRegressor(RegressorMixin, BaseEstimator):
         rnd = check_random_state(self.random_state)
 
         # Torch reproducibility bomb
-        torch.manual_seed(rnd.randint(0, 2**32 - 1))
-        random.seed(rnd.randint(0, 2**32 - 1))
-        np.random.seed(rnd.randint(0, 2**32 - 1))  # noqa: NPY002
+        torch.manual_seed(rnd.randint(0, 2**32 - 1, dtype=np.int64))
+        random.seed(rnd.randint(0, 2**32 - 1, dtype=np.int64))
+        np.random.seed(rnd.randint(0, 2**32 - 1, dtype=np.int64))  # noqa: NPY002
 
         self.predictor_ = AutoPostHocEnsemblePredictor(
             preset=self.preset,
@@ -202,8 +202,8 @@ class AutoTabPFNRegressor(RegressorMixin, BaseEstimator):
             max_time=self.max_time,
             ges_scoring_string=self.ges_scoring_string,
             device=self.device,
-            bm_random_state=rnd.randint(0, 2**32 - 1),
-            ges_random_state=rnd.randint(0, 2**32 - 1),
+            bm_random_state=rnd.randint(0, 2**32 - 1, dtype=np.int64),
+            ges_random_state=rnd.randint(0, 2**32 - 1, dtype=np.int64),
             **self.phe_init_args_,
         )
 


### PR DESCRIPTION
This PR fixes a `ValueError` that occurs when using `rnd.randint` with values exceeding the bounds of `int32`. Specifically, the error occurs because the `high` parameter in `rnd.randint` defaults to `int32`, causing issues when `2**32 - 1` is used. 

The fix ensures compatibility by explicitly setting the `dtype` to `np.int64`.

---

### Changes Made

- Updated calls to `rnd.randint` to include `dtype=np.int64`, as shown below:

**Before:**
```python
rnd.randint(0, 2**32 - 1)
```

**After:**
```python
rnd.randint(0, 2**32 - 1, dtype=np.int64)
```

---

### Reproduced Error

The error message observed is as follows:
```
ValueError: high is out of bounds for int32
```

**Stack Trace:**
```
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
... (truncated for brevity) ...
File numpy\\\\random\\\\mtrand.pyx:780, in numpy.random.mtrand.RandomState.randint()
File numpy\\\\random\\\\_bounded_integers.pyx:2881, in numpy.random._bounded_integers._rand_int32()
```

---

### Impacted Files

The change affects the following files:

- `src/tabpfn_extensions/hpo/tuned_tabpfn.py`
- `src/tabpfn_extensions/post_hoc_ensembles/abstract_validation_utils.py`
- `src/tabpfn_extensions/post_hoc_ensembles/sklearn_interface.py`
---

### Testing

- Verified that the updated code runs without errors.
- Ensured reproducibility by maintaining random state initialization across different configurations.

---

### Checklist

- [x] Updated code to fix the error.
- [x] Verified that the changes do not break existing functionality.
- [x] Added this PR description to document the issue and resolution clearly.

---

### Additional Notes

If you encounter any issues or have suggestions for further improvement, please feel free to comment on this PR.