### PR TITLE
Remove | to make python3.9 compatible

### DIFF
--- a/src/tabpfn_extensions/post_hoc_ensembles/pfn_phe.py
+++ b/src/tabpfn_extensions/post_hoc_ensembles/pfn_phe.py
@@ -374,7 +374,7 @@ class AutoPostHocEnsemblePredictor(BaseEstimator):
         for _, bm in bm_list:
             if isinstance(
                 bm,
-                RandomForestTabPFNClassifier | RandomForestTabPFNClassifier,
+                (RandomForestTabPFNClassifier, RandomForestTabPFNRegressor),
             ):
                 mf = "rf-pfn" + str(bm.tabpfn.model_path)
             elif isinstance(bm, (TabPFNClassifier, TabPFNRegressor)):


### PR DESCRIPTION
Fix #10 
This one wasn't caught by future annotations because it's not in type hints.
I also think there was an error and it was supposed to be RFTab `RandomForestTabPFNClassifier | RandomForestTabPFNRegressor` instead of `RandomForestTabPFNClassifier | RandomForestTabPFNClassifier`. @noahho I think you wrote this, could you check this is correct?