### PR TITLE
Add K-fold Embedding for TabPFN v2

### DIFF
--- a/examples/embedding/README.md
+++ b/examples/embedding/README.md
@@ -1,0 +1,30 @@
+# TabPFN Embeddings
+
+The `TabPFNEmbedding` class is a utility for extracting embeddings from `TabPFNClassifier` or `TabPFNRegressor` models. It supports both standard training (vanilla embeddings) and K-fold cross-validation for embedding extraction. The embeddings can be used to enhance the performance of downstream machine learning models.
+
+## Key Features
+
+- **Vanilla Embeddings**: Extract embeddings by training on the entire dataset when `n_fold=0`.
+- **K-Fold Cross-Validation**: Improve embedding effectiveness by using K-fold cross-validation when `n_fold>0`, as proposed in the paper *"A Closer Look at TabPFN v2: Strength, Limitation, and Extension"*.
+
+## Usage
+
+To use `TabPFNEmbedding`, initialize it with either a `TabPFNClassifier` or `TabPFNRegressor` and specify the number of folds (`n_fold`). Then, call the `get_embeddings` method to generate embeddings for your dataset.
+
+
+
+## Citing This Work
+
+If you use this utility in your research, please cite the following paper:
+
+```bibtex
+@misc{ye2025closerlooktabpfnv2,
+      title={A Closer Look at TabPFN v2: Strength, Limitation, and Extension}, 
+      author={Han-Jia Ye and Si-Yang Liu and Wei-Lun Chao},
+      year={2025},
+      eprint={2502.17361},
+      archivePrefix={arXiv},
+      primaryClass={cs.LG},
+      url={https://arxiv.org/abs/2502.17361}, 
+}
+```

--- a/examples/embedding/get_embeddings.py
+++ b/examples/embedding/get_embeddings.py
@@ -1,0 +1,76 @@
+from sklearn.datasets import fetch_openml
+from sklearn.model_selection import train_test_split
+from sklearn.metrics import  accuracy_score,r2_score
+from sklearn.linear_model import LogisticRegression,LinearRegression
+from tabpfn_extensions import TabPFNClassifier, TabPFNRegressor, TabPFNEmbedding
+
+# Load and evaluate classification dataset
+print("Loading classification dataset (kc1)...")
+X, y = fetch_openml(name='kc1', version=1, as_frame=False, return_X_y=True)
+X_train, X_test, y_train, y_test = train_test_split(
+    X, y, test_size=0.33, random_state=42
+)
+
+# Train and evaluate vanilla logistic regression
+model = LogisticRegression()
+model.fit(X_train, y_train)
+print(f"Baseline Logistic Regression Accuracy: {accuracy_score(y_test, model.predict(X_test)):.4f}")
+
+# Train and evaluate TabPFN embeddings (vanilla)
+clf = TabPFNClassifier(n_estimators=1,random_state=42)
+embedding_extractor = TabPFNEmbedding(tabpfn_clf=clf, n_fold=0)
+train_embeddings = embedding_extractor.get_embeddings(X_train,y_train,X_test,data_source="train")
+test_embeddings = embedding_extractor.get_embeddings(X_train,y_train,X_test,data_source="test")
+
+model = LogisticRegression()
+model.fit(train_embeddings[0], y_train)
+y_pred = model.predict(test_embeddings[0])
+print(f"Logistic Regression with TabPFN (Vanilla) Accuracy: {accuracy_score(y_test, y_pred):.4f}")
+
+
+# Train and evaluate TabPFN embeddings (K-fold cross-validation)
+clf = TabPFNClassifier(n_estimators=1,random_state=42)
+embedding_extractor = TabPFNEmbedding(tabpfn_clf=clf, n_fold=10)
+train_embeddings = embedding_extractor.get_embeddings(X_train,y_train,X_test,data_source="train")
+test_embeddings = embedding_extractor.get_embeddings(X_train,y_train,X_test,data_source="test")
+
+model = LogisticRegression()
+model.fit(train_embeddings[0], y_train)
+y_pred = model.predict(test_embeddings[0])
+print(f"Logistic Regression with TabPFN (K-Fold CV) Accuracy: {accuracy_score(y_test, y_pred):.4f}")
+
+# Load and evaluate regression dataset
+print("\nLoading regression dataset (kin8nm)...")
+X,y = fetch_openml(name='kin8nm' , version=1, as_frame=False, return_X_y=True)
+X_train, X_test, y_train, y_test = train_test_split(
+    X, y, test_size=0.33, random_state=42
+)
+
+# Train and evaluate vanilla linear regression
+model = LinearRegression()
+model.fit(X_train, y_train)
+print(f"Baseline Linear Regression R2 Score: {r2_score(y_test, model.predict(X_test)):.4f}")
+
+# Train and evaluate TabPFN embeddings (vanilla)
+reg = TabPFNRegressor(n_estimators=1,random_state=42)
+embedding_extractor = TabPFNEmbedding(tabpfn_reg=reg, n_fold=0)
+train_embeddings = embedding_extractor.get_embeddings(X_train,y_train,X_test,data_source="train")
+test_embeddings = embedding_extractor.get_embeddings(X_train,y_train,X_test,data_source="test")
+
+model = LinearRegression()
+model.fit(train_embeddings[0], y_train)
+y_pred = model.predict(test_embeddings[0])
+print(f"Linear Regression with TabPFN (Vanilla) R2 Score: {r2_score(y_test, y_pred):.4f}")
+
+
+# Train and evaluate TabPFN embeddings (K-fold cross-validation)
+reg = TabPFNRegressor(n_estimators=1,random_state=42)
+embedding_extractor = TabPFNEmbedding(tabpfn_reg=reg, n_fold=10)
+train_embeddings = embedding_extractor.get_embeddings(X_train,y_train,X_test,data_source="train")
+test_embeddings = embedding_extractor.get_embeddings(X_train,y_train,X_test,data_source="test")
+
+model = LinearRegression()
+model.fit(train_embeddings[0], y_train)
+y_pred = model.predict(test_embeddings[0])
+
+print(f"Linear Regression with TabPFN (K-Fold CV) R2 Score: {r2_score(y_test, y_pred):.4f}")

--- a/src/tabpfn_extensions/embedding/__init__.py
+++ b/src/tabpfn_extensions/embedding/__init__.py
@@ -1,0 +1,7 @@
+"""
+Embedding module for tabpfn_extensions package.
+"""
+
+from .tabpfn_embedding import TabPFNEmbedding
+
+__all__ = ["TabPFNEmbedding"]

--- a/src/tabpfn_extensions/embedding/tabpfn_embedding.py
+++ b/src/tabpfn_extensions/embedding/tabpfn_embedding.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import numpy as np
+from typing import Optional
+
+from tabpfn_extensions import TabPFNRegressor, TabPFNClassifier
+
+class TabPFNEmbedding:
+    """
+    TabPFNEmbedding is a utility for extracting embeddings from TabPFNClassifier or TabPFNRegressor models.
+    It supports standard training (vanilla embedding) as well as K-fold cross-validation for embedding extraction.
+    
+    - When `n_fold=0`, the model extracts vanilla embeddings by training on the entire dataset.
+    - When `n_fold>0`, K-fold cross-validation is applied based on the method proposed in
+      "A Closer Look at TabPFN v2: Strength, Limitation, and Extension" (https://arxiv.org/abs/2502.17361),
+      where a larger `n_fold` improves embedding effectiveness.
+
+    Parameters:
+        tabpfn_clf : TabPFNClassifier, optional
+            An instance of TabPFNClassifier to handle classification tasks.
+        tabpfn_reg : TabPFNRegressor, optional
+            An instance of TabPFNRegressor to handle regression tasks.
+        n_fold : int, default=0
+            Number of folds for K-fold cross-validation. If set to 0, standard training is used.
+
+    Attributes:
+        model : TabPFNClassifier or TabPFNRegressor
+            The model used for embedding extraction.
+    
+    Examples:
+    ```python
+    >>> from tabpfn_extensions import TabPFNClassifier
+    >>> from sklearn.model_selection import train_test_split
+    >>> from sklearn.datasets import fetch_openml
+    >>> X, y = fetch_openml(name='kc1', version=1, as_frame=False, return_X_y=True)
+    >>> X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.33, random_state=42)
+    >>> clf = TabPFNClassifier(n_estimators=1)
+    >>> embedding_extractor = TabPFNEmbedding(tabpfn_clf=clf, n_fold=0)
+    >>> train_embeddings = embedding_extractor.get_embeddings(X_train, y_train, X_test, data_source="train")
+    >>> test_embeddings = embedding_extractor.get_embeddings(X_train, y_train, X_test, data_source="test")
+    ```
+    """
+    
+    def __init__(
+        self,
+        tabpfn_clf: Optional[TabPFNClassifier] = None,
+        tabpfn_reg: Optional[TabPFNRegressor] = None,
+        n_fold: int = 0,
+    ) -> None:
+        """
+        Initializes the TabPFNEmbedding instance.
+
+        Args:
+            tabpfn_clf (Optional[TabPFNClassifier]): An instance of TabPFN classifier (if available).
+            tabpfn_reg (Optional[TabPFNRegressor]): An instance of TabPFN regressor (if available).
+            n_fold (int): Number of folds for cross-validation. If 0, cross-validation is not used.
+        """
+        self.tabpfn_clf = tabpfn_clf
+        self.tabpfn_reg = tabpfn_reg
+        self.model = self.tabpfn_clf if self.tabpfn_clf is not None else self.tabpfn_reg
+        self.n_fold = n_fold
+
+    def fit(self, X_train: np.ndarray, y_train: np.ndarray) -> None:
+        """
+        Trains the TabPFN model on the given dataset.
+
+        Args:
+            X_train (np.ndarray): Training feature data.
+            y_train (np.ndarray): Training target labels.
+
+        Raises:
+            ValueError: If no model is set before calling fit.
+        """
+        if self.model is None:
+            raise ValueError("No model has been set.")
+        self.model.fit(X_train, y_train)
+
+    def get_embeddings(self, X_train: np.ndarray, y_train: np.ndarray, X: np.ndarray, data_source: str) -> np.ndarray:
+        """
+        Extracts embeddings for the given dataset using the trained model.
+        
+        Args:
+            X_train (np.ndarray): Training feature data.
+            y_train (np.ndarray): Training target labels.
+            X (np.ndarray): Data for which embeddings are to be extracted.
+            data_source (str): Specifies the data source ("test" for test data).
+        
+        Returns:
+            np.ndarray: The extracted embeddings.
+        
+        Raises:
+            ValueError: If no model is set before calling get_embeddings.
+        
+        """
+        if self.model is None:
+            raise ValueError("No model has been set.")
+        
+        # If no cross-validation is used, train and return embeddings directly
+
+        if self.n_fold ==0:
+           self.model.fit(X_train, y_train)
+           return self.model.get_embeddings(X,data_source=data_source)
+        elif self.n_fold >=2:
+            if data_source == "test":
+                self.model.fit(X_train, y_train)
+                return self.model.get_embeddings(X,data_source=data_source)
+            else:
+                from sklearn.model_selection import KFold
+                kf = KFold(n_splits=self.n_fold, shuffle=False)
+                embeddings = []
+                for train_index, val_index in kf.split(X_train):
+                    X_train_fold, X_val_fold = X_train[train_index], X_train[val_index]
+                    y_train_fold, y_val_fold = y_train[train_index], y_train[val_index]
+                    self.model.fit(X_train_fold, y_train_fold)
+                    embeddings.append(self.model.get_embeddings(X_val_fold,data_source='test'))
+                return np.concatenate(embeddings, axis=1)
+        else:
+            raise ValueError("n_fold must be greater than 1.")


### PR DESCRIPTION
The embedding extraction method described in [A Closer Look at TabPFN v2: Strength, Limitation, and Extension](https://arxiv.org/abs/2502.17361). Specifically:

- When extracting embeddings for the training set, I split the training set into multiple folds. Each fold is treated as a **query set**, while the remaining folds serve as the **support set**. This allows the extraction of embeddings for each fold separately.
- The embedding extraction for the test set remains the same as in the original implementation.
- With this method, the embeddings of the training set and the test set become more comparable.
