### PR TITLE
Mention paper "Interpretabe Machine Learning for TabPFN"

### DIFF
--- a/src/tabpfn_extensions/interpretability/README.md
+++ b/src/tabpfn_extensions/interpretability/README.md
@@ -12,26 +12,26 @@ computation for TabPFN can be cited as follows:
 
 ```bibtext
 @inproceedings{muschalik2024shapiq,
-  title = {shapiq: Shapley Interactions for Machine Learning},
+  title     = {shapiq: Shapley Interactions for Machine Learning},
   author    = {Maximilian Muschalik and Hubert Baniecki and Fabian Fumagalli and
                Patrick Kolpaczki and Barbara Hammer and Eyke H\"{u}llermeier},
   booktitle = {Advances in Neural Information Processing Systems},
-  pages = {130324--130357},
-  url = {https://openreview.net/forum?id=knxGmi6SJi},
-  volume = {37},
-  year = {2024}
+  pages     = {130324--130357},
+  url       = {https://openreview.net/forum?id=knxGmi6SJi},
+  volume    = {37},
+  year      = {2024}
 }
 ```
 and
 ```bibtext
 @InProceedings{rundel2024interpretableTabPFN,
-  author = {David Rundel and Julius Kobialka and Constantin von Crailsheim and
-            Matthias Feurer and Thomas Nagler and David R{\"u}gamer},
-  title = {Interpretable Machine Learning for TabPFN},
+  author    = {David Rundel and Julius Kobialka and Constantin von Crailsheim and
+               Matthias Feurer and Thomas Nagler and David R{\"u}gamer},
+  title     = {Interpretable Machine Learning for TabPFN},
   booktitle = {Explainable Artificial Intelligence},
-  year = {2024},
-  pages = {465--476},
-  url = {https://link.springer.com/chapter/10.1007/978-3-031-63797-1_23}
+  year      = {2024},
+  pages     = {465--476},
+  url       = {https://link.springer.com/chapter/10.1007/978-3-031-63797-1_23}
 }
 
 ```

--- a/src/tabpfn_extensions/interpretability/README.md
+++ b/src/tabpfn_extensions/interpretability/README.md
@@ -2,21 +2,38 @@
 
 ## TabPFN shapiq
 
-``shapiq`` is a library for computing Shapley-based explanations like Shapley values or Shapley 
-interactions for machine learning models. ``shapiq`` offers native support for interpreting TabPFN
-by utilizing a remove-and-recontextualize paradigm of model interpretation. The library extends the
-well-known SHAP library by providing a more efficient and scalable implementation of Shapley values
-and Shapley interactions. The ``shapiq`` library can be cited as follows:
+``shapiq`` is a library for computing Shapley-based explanations like Shapley values or Shapley
+interactions for machine learning models. The library is a redesigned and improved version of
+the well-known SHAP library that provides a more efficient and scalable implementation of Shapley
+values and Shapley interactions. In addition, ``shapiq`` offers native support for interpreting 
+TabPFN by utilizing a remove-and-recontextualize paradigm of model interpretation tailored towards
+in-context models. The ``shapiq`` library and the paper introducing the improved Shapley value 
+computation for TabPFN can be cited as follows:
 
 ```bibtext
 @inproceedings{muschalik2024shapiq,
-  title     = {shapiq: Shapley Interactions for Machine Learning},
+  title = {shapiq: Shapley Interactions for Machine Learning},
   author    = {Maximilian Muschalik and Hubert Baniecki and Fabian Fumagalli and
                Patrick Kolpaczki and Barbara Hammer and Eyke H\"{u}llermeier},
-  booktitle = {The Thirty-eight Conference on Neural Information Processing Systems Datasets and Benchmarks Track},
-  year      = {2024},
-  url       = {https://openreview.net/forum?id=knxGmi6SJi}
+  booktitle = {Advances in Neural Information Processing Systems},
+  pages = {130324--130357},
+  url = {https://openreview.net/forum?id=knxGmi6SJi},
+  volume = {37},
+  year = {2024}
 }
+```
+and
+```bibtext
+@InProceedings{rundel2024interpretableTabPFN,
+  author = {David Rundel and Julius Kobialka and Constantin von Crailsheim and
+            Matthias Feurer and Thomas Nagler and David R{\"u}gamer},
+  title = {Interpretable Machine Learning for TabPFN},
+  booktitle = {Explainable Artificial Intelligence},
+  year = {2024},
+  pages = {465--476},
+  url = {https://link.springer.com/chapter/10.1007/978-3-031-63797-1_23}
+}
+
 ```
 
 ## TabPFN SHAP


### PR DESCRIPTION
This PR adds a mention of the Shapley value computation method implemented by ``shapiq`` that was published by [Rundel et al. in the paper "Interpretable Machine Learning for TabPFN"](https://link.springer.com/chapter/10.1007/978-3-031-63797-1_23).

CC @davidrundel @mmschlk 