### PR TITLE
add explicit llvmlite dependency to fix uv install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ interpretability = [
 ]
 post_hoc_ensembles = [
     "kditransform>=0.2.0",
+    "llvmlite",
     "hyperopt"
 ]
 hpo = [


### PR DESCRIPTION
Fix #45 
Installation works with pip but not with uv for python>3.9, which handles dependencies differently (in this case using the oldest compatible version of kditransform for some reason. Adding llvmlite explicitly to the dependencies seems to resolve the issue.