### PR TITLE
set minimum seaborn install of single version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "tabpfn-extensions"
 version = "0.0.4"
 dependencies = [
-    "seaborn==0.12.2",
+    "seaborn>=0.12.2",
     "numpy",
     "torch",
     "pandas",


### PR DESCRIPTION
Fix #46 
Tried the examples, they work for seaborn>=12.2 but not below I think.