### PR TITLE
remove llmvite min and upgrade numpy to 2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     "scikit-learn>=1.2.0,<1.7",
     "scipy>=1.7.3,<2",
     "tabpfn>=2.0.6",
-    "numpy>=1.21.0,<2",
+    "numpy>=1.21.0,<3",
 ]
 
 requires-python = ">=3.9"
@@ -60,7 +60,7 @@ interpretability = [
 ]
 post_hoc_ensembles = [
     "kditransform>=0.2.0",
-    "llvmlite>=0.30.0",
+    "llvmlite",
     "hyperopt>=0.2.7"
 ]
 hpo = [


### PR DESCRIPTION
Fix #60 
Removing llvmlite minimum version makes everything work with `numpy<3` instead of `numpy<2`. This is an issue with uv that we already encountered in #47.
Removing the min version shouldn't change anything because kditransform>= 0.2 implies numba >=0.48 which implies llvmlite >=0.31dev.