### PR TITLE
Fix 58: Unify max_depth handling across models

### DIFF
--- a/src/tabpfn_extensions/hpo/tuned_tabpfn.py
+++ b/src/tabpfn_extensions/hpo/tuned_tabpfn.py
@@ -283,11 +283,13 @@ class TunedTabPFNBase(BaseEstimator):
                     return {"loss": float("inf"), "status": STATUS_OK}
 
             try:
+                # Extract decision tree specific parameters
+                # and remove them from model_params so that
+                # instances of TabPFNClassifier or
+                # TabPFNRegressor can be initialized properly
+                max_depth = model_params.pop("max_depth", 3)
                 # Create and fit model based on model type
                 if model_type == "dt_pfn":
-                    # Extract decision tree specific parameters
-                    max_depth = model_params.pop("max_depth", 3)
-
                     if task_type in ["binary", "multiclass"]:
                         # Use TabPFNClassifier as the base model for DT
                         base_model = TabPFNClassifier(**model_params)


### PR DESCRIPTION
### Summary

This PR unifies how `max_depth` is handled by extracting and removing it from `model_params` for all model types.

### Changes

- Moved `max_depth = model_params.pop("max_depth", 3)` outside of the `if model_type == "dt_pfn"` block.
- Added explanatory comment above the line for clarity.

`max_depth` is not a valid parameter for `TabPFNClassifier` or `TabPFNRegressor`. As a result, without this PR, instances of these classes cannot be created if `model_type` is not `dt_pfn`. This PR ensures that `model_params` does not include `max_depth` for any `model_type`.

### Related Issue

Fixes #58 