### PR TITLE
Support for DAG in unsupervised synthesis / imputation

### DIFF
--- a/examples/unsupervised/generate_data_following_dag.py
+++ b/examples/unsupervised/generate_data_following_dag.py
@@ -1,0 +1,79 @@
+#  Copyright (c) Prior Labs GmbH 2025.
+#  Licensed under the Apache License, Version 2.0
+
+import torch
+from sklearn.datasets import load_wine
+from sklearn.model_selection import train_test_split
+
+from tabpfn_extensions import TabPFNClassifier, unsupervised
+
+# Load the breast cancer dataset
+df = load_wine(return_X_y=False)
+X, y = df["data"], df["target"]
+attribute_names = df["feature_names"]
+
+wine_dag = {
+    'alcohol': [],
+    'malic_acid': [],
+    'ash': ['magnesium'],
+    'alcalinity_of_ash': ['ash', 'magnesium'],
+    'magnesium': [],
+    'total_phenols': ['flavanoids', 'nonflavanoid_phenols', 'proanthocyanins'],
+    'flavanoids': [],
+    'nonflavanoid_phenols': [],
+    'proanthocyanins': [],
+    'color_intensity': ['flavanoids', 'proanthocyanins', 'total_phenols'],
+    'hue': ['color_intensity'],
+    'od280/od315_of_diluted_wines': ['flavanoids', 'total_phenols'],
+    'proline': ['alcohol', 'total_phenols']
+}
+
+# convert feature names to indices in keys and values
+dag = {i: [list(wine_dag.keys()).index(dep) for dep in deps] for i, deps in enumerate(wine_dag.values())}
+print(dag)
+
+# Split the data
+X_train, X_test, y_train, y_test = train_test_split(
+    X,
+    y,
+    test_size=0.5,
+    random_state=42,
+)
+
+# Initialize TabPFN models
+# Use parameters that work with both TabPFN and TabPFN-client
+clf = TabPFNClassifier(n_estimators=3)
+
+# Import TabPFNRegressor for numerical features
+from tabpfn_extensions import TabPFNRegressor
+
+reg = TabPFNRegressor(n_estimators=3)
+
+# Initialize unsupervised model
+model_unsupervised = unsupervised.TabPFNUnsupervisedModel(
+    tabpfn_clf=clf,
+    tabpfn_reg=reg,
+)
+
+# Create and run synthetic experiment
+exp_synthetic = unsupervised.experiments.GenerateSyntheticDataExperiment(
+    task_type="unsupervised",
+)
+
+# Convert data to torch tensors
+X_tensor = torch.tensor(X_train, dtype=torch.float32)
+y_tensor = torch.tensor(y_train, dtype=torch.float32)
+
+# Run the experiment
+results = exp_synthetic.run(
+    tabpfn=model_unsupervised,
+    X=X_tensor,
+    y=y_tensor,
+    attribute_names=attribute_names,
+    temp=1.0,
+    n_samples=X_train.shape[0] * 3,  # Generate 3x original samples
+    indices=list(range(X_train.shape[1])),  # Use all features
+    n_permutations=3,
+    dag=dag,
+)
+

--- a/examples/unsupervised/generate_data_following_dag.py
+++ b/examples/unsupervised/generate_data_following_dag.py
@@ -1,0 +1,74 @@
+#  Copyright (c) Prior Labs GmbH 2025.
+#  Licensed under the Apache License, Version 2.0
+"""Example: causally-informed synthetic data via a DAG.
+
+Shows how to pass a Directed Acyclic Graph of inter-feature dependencies to
+``TabPFNUnsupervisedModel.generate_synthetic_data``. With a DAG, each feature
+is generated in topological order and conditioned only on its declared
+parents — useful for counterfactual generation or scenarios where the user
+encodes domain knowledge about feature dependencies.
+
+NB: the DAG used here is **illustrative only**, not a validated causal model
+of wine chemistry. Replace it with your domain's actual DAG.
+"""
+import torch
+from sklearn.datasets import load_wine
+from sklearn.model_selection import train_test_split
+
+from tabpfn_extensions import TabPFNClassifier, TabPFNRegressor, unsupervised
+
+df = load_wine(return_X_y=False)
+X, y = df["data"], df["target"]
+attribute_names = df["feature_names"]
+
+# Illustrative DAG over wine features. Each key depends on the listed parents.
+wine_dag_by_name = {
+    "alcohol": [],
+    "malic_acid": [],
+    "ash": ["magnesium"],
+    "alcalinity_of_ash": ["ash", "magnesium"],
+    "magnesium": [],
+    "total_phenols": ["flavanoids", "nonflavanoid_phenols", "proanthocyanins"],
+    "flavanoids": [],
+    "nonflavanoid_phenols": [],
+    "proanthocyanins": [],
+    "color_intensity": ["flavanoids", "proanthocyanins", "total_phenols"],
+    "hue": ["color_intensity"],
+    "od280/od315_of_diluted_wines": ["flavanoids", "total_phenols"],
+    "proline": ["alcohol", "total_phenols"],
+}
+
+# Convert feature-name DAG → integer-index DAG (the public API expects ints)
+name_to_idx = {n: i for i, n in enumerate(attribute_names)}
+dag = {
+    name_to_idx[child]: [name_to_idx[p] for p in parents]
+    for child, parents in wine_dag_by_name.items()
+}
+
+X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.5, random_state=42)
+
+clf = TabPFNClassifier(n_estimators=3)
+reg = TabPFNRegressor(n_estimators=3)
+model_unsupervised = unsupervised.TabPFNUnsupervisedModel(
+    tabpfn_clf=clf,
+    tabpfn_reg=reg,
+)
+
+exp_synthetic = unsupervised.experiments.GenerateSyntheticDataExperiment(
+    task_type="unsupervised",
+)
+
+X_tensor = torch.tensor(X_train, dtype=torch.float32)
+y_tensor = torch.tensor(y_train, dtype=torch.float32)
+
+results = exp_synthetic.run(
+    tabpfn=model_unsupervised,
+    X=X_tensor,
+    y=y_tensor,
+    attribute_names=attribute_names,
+    temp=1.0,
+    n_samples=X_train.shape[0] * 3,  # 3x original samples
+    indices=list(range(X_train.shape[1])),
+    n_permutations=3,
+    dag=dag,
+)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tabpfn-extensions"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
     "torch>=2.1,<3",
     "pandas>=1.4.0,<3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tabpfn-extensions"
-version = "0.4.1"
+version = "0.1.1"
 dependencies = [
     "torch>=2.1",
     "pandas>=2.2.2",

--- a/src/tabpfn_extensions/unsupervised/experiments.py
+++ b/src/tabpfn_extensions/unsupervised/experiments.py
@@ -116,6 +116,9 @@ class GenerateSyntheticDataExperiment(Experiment):
 
             temp = kwargs.get("temp", 1.0)
             n_samples = kwargs.get("n_samples", X.shape[0])
+            
+            n_permutations = kwargs.get("n_permutations", 1)
+            dag = kwargs.get("dag", None)
 
             self.X, self.y = X, y
             self.X = self.X[:, indices]
@@ -133,6 +136,8 @@ class GenerateSyntheticDataExperiment(Experiment):
             self.synthetic_X = tabpfn.generate_synthetic_data(
                 n_samples=n_samples,
                 t=temp,
+                n_permutations=n_permutations,
+                dag=dag,
             )
 
             data_real = pd.DataFrame(

--- a/src/tabpfn_extensions/unsupervised/experiments.py
+++ b/src/tabpfn_extensions/unsupervised/experiments.py
@@ -116,6 +116,8 @@ class GenerateSyntheticDataExperiment(Experiment):
 
             temp = kwargs.get("temp", 1.0)
             n_samples = kwargs.get("n_samples", X.shape[0])
+            n_permutations = kwargs.get("n_permutations", 3)
+            dag = kwargs.get("dag", None)
 
             self.X, self.y = X, y
             self.X = self.X[:, indices]
@@ -133,6 +135,8 @@ class GenerateSyntheticDataExperiment(Experiment):
             self.synthetic_X = tabpfn.generate_synthetic_data(
                 n_samples=n_samples,
                 t=temp,
+                n_permutations=n_permutations,
+                dag=dag,
             )
 
             data_real = pd.DataFrame(

--- a/src/tabpfn_extensions/unsupervised/unsupervised.py
+++ b/src/tabpfn_extensions/unsupervised/unsupervised.py
@@ -309,11 +309,7 @@ class TabPFNUnsupervisedModel(BaseEstimator):
             ts = TopologicalSorter(dag)
             # re-order all_features based on the DAG (throws error in case of cycles)
             all_features = list(ts.static_order())
-            # re-order also the indices of categorical features accordingly
-            self.categorical_features = [
-                all_features.index(idx) for idx in self.categorical_features
-            ]
-            
+        
         for i in tqdm(range(len(all_features))):
             column_idx = all_features[i]
 
@@ -528,8 +524,8 @@ class TabPFNUnsupervisedModel(BaseEstimator):
         else:
             # If the first feature, use a zero feature as input
             # Because of preprocessing, we can't use a zero feature, so we use a random feature
-            X_fit, y_fit = torch.randn_like(X_fit[:, 0:1]), X_fit[:, 0]
-            X_predict, y_predict = torch.randn_like(X_predict[:, 0:1]), X_predict[:, 0]
+            X_fit, y_fit = torch.randn_like(X_fit[:, 0:1]), X_fit[:, column_idx]
+            X_predict, y_predict = torch.randn_like(X_predict[:, 0:1]), X_predict[:, column_idx]
 
         model = (
             self.tabpfn_clf

--- a/src/tabpfn_extensions/unsupervised/unsupervised.py
+++ b/src/tabpfn_extensions/unsupervised/unsupervised.py
@@ -302,6 +302,10 @@ class TabPFNUnsupervisedModel(BaseEstimator):
                 raise ValueError(
                     "DAG cannot be used with condition_on_all_features=True."
                 )
+            # fill up the DAG with empty lists for features not in the DAG
+            for i in all_features:
+                if i not in dag:
+                    dag[i] = []
             # the following will raise an error if the DAG is not a valid DAG
             ts = TopologicalSorter(dag)
             ts.static_order()

--- a/src/tabpfn_extensions/unsupervised/unsupervised.py
+++ b/src/tabpfn_extensions/unsupervised/unsupervised.py
@@ -306,11 +306,13 @@ class TabPFNUnsupervisedModel(BaseEstimator):
             for i in all_features:
                 if i not in dag:
                     dag[i] = []
-            # the following will raise an error if the DAG is not a valid DAG
             ts = TopologicalSorter(dag)
-            ts.static_order()
-            # re-order all_features based on the DAG
+            # re-order all_features based on the DAG (throws error in case of cycles)
             all_features = list(ts.static_order())
+            # re-order also the indices of categorical features accordingly
+            self.categorical_features = [
+                all_features.index(idx) for idx in self.categorical_features
+            ]
             
         for i in tqdm(range(len(all_features))):
             column_idx = all_features[i]

--- a/src/tabpfn_extensions/unsupervised/unsupervised.py
+++ b/src/tabpfn_extensions/unsupervised/unsupervised.py
@@ -15,6 +15,8 @@ Key features:
 - Compatibility with both TabPFN and TabPFN-client backends
 - Support for mixed data types (categorical and numerical features)
 - Flexible permutation-based approach for feature dependencies
+- Optional Directed Acyclic Graph (DAG) of inter-feature dependencies for
+  causally-informed synthesis / imputation
 
 Example usage:
     ```python
@@ -43,6 +45,7 @@ from __future__ import annotations
 import copy
 import os
 import random
+from graphlib import CycleError, TopologicalSorter
 from typing import Any
 
 import numpy as np
@@ -58,6 +61,32 @@ from tabpfn_extensions.utils import (  # type: ignore
     TabPFNRegressor,
     infer_categorical_features,
 )
+
+
+def _resolve_dag_order(
+    dag: dict[int, list[int]],
+    all_features: list[int],
+) -> tuple[list[int], dict[int, list[int]]]:
+    """Topologically order ``all_features`` according to ``dag``.
+
+    Returns ``(ordered, full_dag)`` where ``ordered`` is a permutation of
+    ``all_features`` consistent with the DAG, and ``full_dag`` is a copy of
+    ``dag`` with empty dependency lists filled in for any feature not present
+    as a key.
+
+    The caller's ``dag`` is **not** mutated. On a cyclic graph we raise
+    ``ValueError`` with the cycle path embedded in the message — easier for a
+    user to debug than the raw stdlib ``CycleError`` traceback.
+    """
+    full_dag = {i: list(dag.get(i, [])) for i in all_features}
+    try:
+        ordered = list(TopologicalSorter(full_dag).static_order())
+    except CycleError as exc:
+        cycle = exc.args[1] if len(exc.args) > 1 else exc.args[0]
+        raise ValueError(
+            f"DAG contains a cycle through features: {cycle}"
+        ) from exc
+    return ordered, full_dag
 
 
 class TabPFNUnsupervisedModel(BaseEstimator):
@@ -270,6 +299,7 @@ class TabPFNUnsupervisedModel(BaseEstimator):
         t: float = 0.000000001,
         n_permutations: int = 10,
         condition_on_all_features: bool = True,
+        dag: dict[int, list[int]] | None = None,
         fast_mode: bool = False,
     ) -> torch.Tensor:
         """Impute missing values (np.nan) in X by sampling all cells independently from the trained models.
@@ -283,11 +313,22 @@ class TabPFNUnsupervisedModel(BaseEstimator):
                 Number of permutations to use for imputation
             condition_on_all_features: bool, default=True
                 Whether to condition on all other features (True) or only previous features (False)
+            dag: dict[int, list[int]] | None, default=None
+                Optional Directed Acyclic Graph mapping each column index to its
+                list of parent column indices (i.e. the features it depends on).
+                When provided, columns are imputed in topological order and each
+                column is conditioned on exactly its DAG parents. Mutually
+                exclusive with ``condition_on_all_features=True``. Features
+                absent from the dict default to no dependencies.
             fast_mode: bool, default=False
                 Whether to use faster settings for testing
 
         Returns:
             torch.Tensor: Imputed data with missing values replaced
+
+        Raises:
+            ValueError: If ``dag`` is combined with ``condition_on_all_features=True``,
+                or if ``dag`` contains a cycle.
         """
         n_features = X.shape[1]
         all_features = list(range(n_features))
@@ -295,19 +336,42 @@ class TabPFNUnsupervisedModel(BaseEstimator):
         X_fit = self.X_
         impute_X = copy.deepcopy(X)
 
+        # Resolve DAG iteration order up front, once. After this block:
+        #   - ``full_dag`` is a local copy (caller's dict is never mutated)
+        #   - ``topo_order`` is a topo-consistent permutation of all_features
+        full_dag: dict[int, list[int]] | None = None
+        topo_order: list[int] | None = None
+        if dag is not None:
+            if condition_on_all_features:
+                raise ValueError(
+                    "`dag` is mutually exclusive with "
+                    "`condition_on_all_features=True`; pass "
+                    "condition_on_all_features=False when supplying a DAG."
+                )
+            topo_order, full_dag = _resolve_dag_order(dag, all_features)
+
         columns_with_nan = [
             col_idx
             for col_idx in all_features
             if torch.isnan(impute_X[:, col_idx]).any()
         ]
+        # When a DAG is provided, impute parents before children even within
+        # the subset that has NaNs.
+        if topo_order is not None:
+            with_nan_set = set(columns_with_nan)
+            columns_with_nan = [c for c in topo_order if c in with_nan_set]
+
+        def _conditional_idx_for(column_idx: int) -> list[int]:
+            # Single place that knows the conditioning rule per call mode.
+            if full_dag is not None:
+                return full_dag[column_idx]
+            if not condition_on_all_features:
+                return all_features[:column_idx] if column_idx > 0 else []
+            return list(set(range(X.shape[1])) - {column_idx})
 
         for column_idx in tqdm(columns_with_nan):
             y_predict = impute_X[:, column_idx]
-
-            if not condition_on_all_features:
-                conditional_idx = all_features[:column_idx] if column_idx > 0 else []
-            else:
-                conditional_idx = list(set(range(X.shape[1])) - {column_idx})
+            conditional_idx = _conditional_idx_for(column_idx)
 
             X_where_y_is_nan = impute_X[torch.isnan(y_predict)]
             X_where_y_is_nan = X_where_y_is_nan.reshape(-1, impute_X.shape[1])
@@ -509,13 +573,20 @@ class TabPFNUnsupervisedModel(BaseEstimator):
             X_predict, y_predict = X_predict[mask], X_predict[:, column_idx]
             X_predict = X_predict.reshape(mask.shape[0], -1)
         else:
-            # If the first feature, use a zero feature as input
-            # Because of preprocessing, we can't use a zero feature, so we use a random feature
+            # No conditional features for this column. Use a random feature as a
+            # placeholder input, but make the target `y` come from `column_idx`,
+            # not from literal column 0. Important when the caller has reordered
+            # iteration order (e.g. via a DAG): "first feature processed" is no
+            # longer column 0, so reading column 0 as the target would predict
+            # the wrong variable.
             X_fit, y_fit = (
                 torch.randn(X_fit[:, 0:1].shape, dtype=torch.float32),
-                X_fit[:, 0],
+                X_fit[:, column_idx],
             )
-            X_predict, y_predict = torch.randn_like(X_predict[:, 0:1]), X_predict[:, 0]
+            X_predict, y_predict = (
+                torch.randn_like(X_predict[:, 0:1]),
+                X_predict[:, column_idx],
+            )
 
         model = (
             self.tabpfn_clf
@@ -543,6 +614,7 @@ class TabPFNUnsupervisedModel(BaseEstimator):
         X: torch.Tensor | np.ndarray | pd.DataFrame,
         t: float = 0.000000001,
         n_permutations: int = 10,
+        dag: dict[int, list[int]] | None = None,
     ) -> torch.Tensor:
         """Impute missing values in the input data using the fitted TabPFN models.
 
@@ -564,6 +636,13 @@ class TabPFNUnsupervisedModel(BaseEstimator):
                 Number of random feature permutations to use for imputation.
                 Higher values may improve robustness but increase computation time.
 
+            dag: dict[int, list[int]] | None, default=None
+                Optional Directed Acyclic Graph mapping each column index to the
+                list of column indices it depends on. When provided, columns are
+                imputed in topological order and each column is conditioned on
+                its DAG parents instead of all other features. Useful for
+                causally-informed imputation.
+
         Returns:
             torch.Tensor
                 Imputed data with missing values replaced, of shape (n_samples, n_features).
@@ -583,8 +662,9 @@ class TabPFNUnsupervisedModel(BaseEstimator):
         return self.impute_(
             X,
             t,
-            condition_on_all_features=True,
+            condition_on_all_features=(dag is None),
             n_permutations=n_permutations,
+            dag=dag,
             fast_mode=fast_mode,
         )
 
@@ -759,6 +839,7 @@ class TabPFNUnsupervisedModel(BaseEstimator):
         n_samples: int = 100,
         t: float = 1.0,
         n_permutations: int = 3,
+        dag: dict[int, list[int]] | None = None,
     ) -> torch.Tensor:
         """Generate synthetic tabular data samples using the fitted TabPFN models.
 
@@ -778,6 +859,12 @@ class TabPFNUnsupervisedModel(BaseEstimator):
             n_permutations: int, default=3
                 Number of feature permutations to use for generation
                 More permutations may provide more robust results but increase computation time
+
+            dag: dict[int, list[int]] | None, default=None
+                Optional Directed Acyclic Graph mapping each column index to the
+                list of column indices it depends on. When provided, columns are
+                generated in topological order and each column is conditioned on
+                its DAG parents only. Useful for causally-informed synthesis.
 
         Returns:
             torch.Tensor:
@@ -810,6 +897,7 @@ class TabPFNUnsupervisedModel(BaseEstimator):
             t=t,
             condition_on_all_features=False,
             n_permutations=actual_n_permutations,
+            dag=dag,
             fast_mode=fast_mode,
         )
 

--- a/tests/test_unsupervised_dag.py
+++ b/tests/test_unsupervised_dag.py
@@ -1,0 +1,92 @@
+"""Tests for DAG-conditioned synthesis / imputation.
+
+The pure-Python ordering / cycle / mutation tests run instantly and need no
+TabPFN model. The end-to-end synthesis test uses ``FAST_TEST_MODE=1`` and
+``n_estimators=1`` so it stays in the per-test budget on the existing CI.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import torch
+
+from tabpfn_extensions import TabPFNClassifier, TabPFNRegressor, unsupervised
+from tabpfn_extensions.unsupervised.unsupervised import _resolve_dag_order
+
+
+# ─────────────────────────── helper-level tests ──────────────────────────────
+
+
+def test_resolve_dag_order_basic():
+    """Topological order respects parent → child."""
+    dag = {0: [], 1: [0], 2: [1, 0]}
+    ordered, full = _resolve_dag_order(dag, [0, 1, 2])
+    assert ordered.index(0) < ordered.index(1)
+    assert ordered.index(0) < ordered.index(2)
+    assert ordered.index(1) < ordered.index(2)
+    assert full == {0: [], 1: [0], 2: [1, 0]}
+
+
+def test_resolve_dag_order_partial():
+    """Features with no explicit deps get empty parents."""
+    ordered, full = _resolve_dag_order({2: [0, 1]}, [0, 1, 2, 3])
+    assert ordered.index(2) > ordered.index(0)
+    assert ordered.index(2) > ordered.index(1)
+    assert set(ordered) == {0, 1, 2, 3}
+    assert full[0] == [] and full[3] == []
+
+
+def test_resolve_dag_order_cycle_raises_valueerror():
+    """Cycles surface as ValueError, not stdlib CycleError traceback."""
+    with pytest.raises(ValueError, match="cycle"):
+        _resolve_dag_order({0: [1], 1: [0]}, [0, 1])
+
+
+def test_resolve_dag_order_does_not_mutate_caller_dict():
+    """Filling in empty deps must not write into the caller's dict."""
+    user_dag = {2: [0, 1]}
+    snapshot = dict(user_dag)
+    _resolve_dag_order(user_dag, [0, 1, 2, 3])
+    assert user_dag == snapshot, "caller's DAG dict was mutated"
+
+
+# ─────────────────────────── public API tests ────────────────────────────────
+
+
+def test_impute_rejects_dag_with_condition_on_all_features():
+    """The two modes are mutually exclusive — must raise a clear ValueError."""
+    X = torch.tensor(np.random.rand(5, 3), dtype=torch.float32)
+    model = unsupervised.TabPFNUnsupervisedModel(
+        tabpfn_clf=TabPFNClassifier(n_estimators=1),
+        tabpfn_reg=TabPFNRegressor(n_estimators=1),
+    )
+    model.fit(X)
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        model.impute_(
+            X,
+            condition_on_all_features=True,
+            dag={0: [], 1: [0], 2: [0, 1]},
+        )
+
+
+@pytest.mark.client_compatible
+@pytest.mark.local_compatible
+def test_generate_synthetic_data_with_dag(monkeypatch):
+    """End-to-end: generation with a DAG returns the right shape."""
+    monkeypatch.setenv("FAST_TEST_MODE", "1")
+
+    X = np.random.rand(5, 3).astype(np.float32)
+    X_tensor = torch.tensor(X)
+    model = unsupervised.TabPFNUnsupervisedModel(
+        tabpfn_clf=TabPFNClassifier(n_estimators=1),
+        tabpfn_reg=TabPFNRegressor(n_estimators=1),
+    )
+    model.fit(X_tensor)
+
+    # 0 is independent; 1 depends on 0; 2 depends on 0 and 1
+    dag = {0: [], 1: [0], 2: [0, 1]}
+    synthetic_X = model.generate_synthetic_data(n_samples=5, dag=dag)
+
+    assert isinstance(synthetic_X, torch.Tensor)
+    assert synthetic_X.shape == (5, 3)


### PR DESCRIPTION
Hi,

This PR is includes the support for causal DAGs in synthetic data generation/imputation.
DAGs are expressed as a dictionary `{ int: list[int] }` where the key is the depenent column_idx and the value is a list of column indices the key depends on.
E.g. for column 0 independent, column 1 depending on 0, column 2 depending on 1 and 0, you'd have:
```
{ 0: [], 1: [0], 2: [1,0] }
```

The PR modifies (IMHO minimally) `src/tabpfn_extensions/unsupervised/unsupervised.py` and adds a respective `examples/unsupervised/generate_data_following_dag.py`. Some small changes apply to other files.

Regarding the `src` file:
- enables to pass the dag dictionary to appropriate function calls.
- read the dag dictionary in `impute_` and order the variables using python's `graphlib TopologicalSorter` to synthesize them in the right order (e.g. independent first)
- set the `conditional_idx` of the `column_idx` being generated/imputed to its dependencies (e.g., if `column_idx==2` then `conditional_idx==[0,1]`)
- proceed as before

What this PR does **not** do (based on the contribution guidelines):
- does not create a new extension and applicable aspects
- does not include tests (!!!) Unfortunately I see no tests for `unsupervised` to add to (am I missing something?). I hope the limited scope of the proposed changes + the provided example suffice. If you feel otherwise, it would be great if a test suite for `unsupervised` is created, to which we could then add tests specific to the addition of dag support.