### PR TITLE
Fix ROC AUC bug: handle binary and multiclass predict_proba outputs correctly

### DIFF
--- a/src/tabpfn_extensions/hpo/tuned_tabpfn.py
+++ b/src/tabpfn_extensions/hpo/tuned_tabpfn.py
@@ -275,7 +275,10 @@ class TunedTabPFNBase(BaseEstimator):
                         score = model.score(X_val, y_val)
                     elif self.metric in [MetricType.ROC_AUC]:
                         y_pred = model.predict_proba(X_val)
-                        score = roc_auc_score(y_val, y_pred, multi_class="ovr")
+                        if y_pred.ndim == 2 and y_pred.shape[1] == 2:  # Binary
+                            score = roc_auc_score(y_val, y_pred[:, 1])
+                        else:
+                            score = roc_auc_score(y_val, y_pred, multi_class="ovr")
                     elif self.metric == MetricType.F1:
                         y_pred = model.predict(X_val)
                         score = f1_score(y_val, y_pred, average="weighted")


### PR DESCRIPTION
This PR fixes a bug in the computation of ROC AUC during hyperparameter tuning:
When using model.predict_proba(X_val) in binary classification, the code previously passed the full 2D array to roc_auc_score, which caused a shape error.
Now, the code detects the shape of y_pred and, if it is a 2D array (binary), correctly passes y_pred[:, 1] as the predicted probability for the positive class. For multiclass, it uses the multiclass mode.