### PR TITLE
Set TABPFN_EXCLUDE_DEVICES Env flag on CI

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -82,6 +82,8 @@ jobs:
 
       - name: Run Tests (Unix)
         if: runner.os != 'Windows'
+        env:
+          TABPFN_EXCLUDE_DEVICES: "mps"
         run: |
           FAST_TEST_MODE=1 pytest tests/
 


### PR DESCRIPTION
Set `TABPFN_EXCLUDE_DEVICES` env variable on CI identical to TabPFN main package, as a result of low-memory MPS processors on CI. 