### PR TITLE
Add matplotlib dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ name = "tabpfn-extensions"
 version = "0.1.4"
 dependencies = [
     "torch>=2.1,<3",
+    "matplotlib>=3.4,<4",
     "pandas>=1.4.0,<3",
     "scikit-learn>=1.2.0,<1.7",
     "scipy>=1.11.1,<2",


### PR DESCRIPTION
Fix #157 
## Summary
- add matplotlib to core dependencies
- require matplotlib>=3.4 for Python 3.9 support

## Testing
- `pre-commit run --files pyproject.toml`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68ba977ed2f8832a99752fdee6a29e45