### PR TITLE
Run the tests on push to main, and also when requested.

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -3,6 +3,9 @@ on:
   pull_request:
     branches:
       - main
+  push:
+    branches: [main]
+  workflow_dispatch:
 
 jobs:
   check_python_linting:
@@ -18,7 +21,7 @@ jobs:
         with:
           src: "./src ./tests"
           version: 0.8.6
-          args: 'format --check'
+          args: "format --check"
 
   test_compatibility:
     name: Test Package Compatibility


### PR DESCRIPTION
At the moment we only run the tests in PRs, but this can mean that the tests are broken after merge to main due to interactions with concurrent PRs.

Also add a "workflow_dispatch" trigger so we can run the tests manually.