### PR TITLE
Make scikit-survival an optional user-install for SurvivalTabPFN

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,8 +71,8 @@ hpo = [
     # https://discuss.python.org/t/pkg-resources-removal-how-to-go-from-there/106079
     "setuptools>=67.0.0,<82",
 ]
-# [survival] extra is empty; install scikit-survival manually if you need
-# SurvivalTabPFN: `pip install scikit-survival`.
+# Install scikit-survival manually if you need SurvivalTabPFN
+# `pip install scikit-survival`. Excluded due to GPL.
 survival = []
 many_class = []
 classifier_as_regressor = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,9 +71,9 @@ hpo = [
     # https://discuss.python.org/t/pkg-resources-removal-how-to-go-from-there/106079
     "setuptools>=67.0.0,<82",
 ]
-survival = [
-    "scikit-survival>=0.25.0; python_version >= '3.10'",
-]
+# [survival] extra is empty; install scikit-survival manually if you need
+# SurvivalTabPFN: `pip install scikit-survival`.
+survival = []
 many_class = []
 classifier_as_regressor = []
 rf_pfn = []
@@ -90,8 +90,7 @@ all = [
     # https://discuss.python.org/t/pkg-resources-removal-how-to-go-from-there/106079
     "setuptools>=67.0.0,<82",
     "autogluon.tabular==1.4.0",
-
-    "scikit-survival>=0.25.0; python_version >= '3.10'",
+    # scikit-survival not included; install manually if you need SurvivalTabPFN.
 ]
 
 [dependency-groups]

--- a/src/tabpfn_extensions/survival/__init__.py
+++ b/src/tabpfn_extensions/survival/__init__.py
@@ -1,5 +1,7 @@
 # INFO: The survival prediction work is work-in-progress and still unoptimized,
 #  TabPFN survival may provide inconsistent improvements.
+#
+# Requires scikit-survival (install manually with `pip install scikit-survival`).
 
 from .survival import SurvivalTabPFN
 

--- a/src/tabpfn_extensions/survival/survival.py
+++ b/src/tabpfn_extensions/survival/survival.py
@@ -12,8 +12,18 @@ from typing import Literal
 import numpy as np
 import torch
 from sklearn.base import BaseEstimator
-from sksurv.base import SurvivalAnalysisMixin
-from sksurv.util import check_y_survival
+
+# scikit-survival is an optional dependency; install with
+# `pip install scikit-survival` if you need SurvivalTabPFN.
+try:
+    from sksurv.base import SurvivalAnalysisMixin
+    from sksurv.util import check_y_survival
+except ImportError as _err:  # pragma: no cover
+    raise ImportError(
+        "SurvivalTabPFN requires scikit-survival. Install it with:\n\n"
+        "    pip install scikit-survival"
+    ) from _err
+
 from tabpfn_common_utils.telemetry import set_extension
 
 from tabpfn_extensions.utils import TabPFNClassifier, TabPFNRegressor

--- a/src/tabpfn_extensions/survival/survival.py
+++ b/src/tabpfn_extensions/survival/survival.py
@@ -21,7 +21,7 @@ try:
 except ImportError as _err:  # pragma: no cover
     raise ImportError(
         "SurvivalTabPFN requires scikit-survival. Install it with:\n\n"
-        "    pip install scikit-survival"
+        "    pip install scikit-survival. Excluded due to GPL."
     ) from _err
 
 from tabpfn_common_utils.telemetry import set_extension


### PR DESCRIPTION
## Summary

- Drop `scikit-survival` from the `[survival]` and `[all]` optional extras
- `tabpfn_extensions.survival` raises a clear `ImportError` with install instructions if `scikit-survival` is not present
- Short note added in the survival package `__init__.py`

## Why

`scikit-survival` is only used by `SurvivalTabPFN`. Making it a manual install keeps the default install lighter for everyone who doesn't need it.

## Behaviour

| Command | Result |
|---|---|
| `pip install tabpfn-extensions[all]` | Lighter install; no scikit-survival |
| `pip install tabpfn-extensions[survival]` | Valid no-op target; no extra deps |
| `pip install scikit-survival` then use `SurvivalTabPFN` | Works unchanged |
| Use `SurvivalTabPFN` without scikit-survival | `ImportError` pointing at `pip install scikit-survival` |

## Test plan

- [ ] `tests/test_survival.py` passes when scikit-survival is installed
- [ ] `from tabpfn_extensions.survival import SurvivalTabPFN` raises the expected ImportError when it isn't

🤖 Generated with [Claude Code](https://claude.com/claude-code)