### PR TITLE
[PRI-269] AutoTabPFN diagnostics + per-checkpoint AutoGluon limits

### DIFF
--- a/src/tabpfn_extensions/hpo/search_space.py
+++ b/src/tabpfn_extensions/hpo/search_space.py
@@ -163,9 +163,9 @@ def get_param_grid_hyperopt(
         )
 
     else:
-        raise ValueError(
-            f"Unknown combination of task type {task_type} and "
-            "model version {model_version}!"
+        raise NotImplementedError(
+            f"No hpo search space is defined for task type {task_type} and "
+            f"model version {model_version}."
         )
 
     # Make sure models are downloaded.

--- a/src/tabpfn_extensions/post_hoc_ensembles/sklearn_interface.py
+++ b/src/tabpfn_extensions/post_hoc_ensembles/sklearn_interface.py
@@ -80,9 +80,14 @@ class AutoTabPFNBase(BaseEstimator):
         The number of internal transformers to ensemble within each individual TabPFN model.
         Higher values can improve performance but increase resource usage.
     ignore_pretraining_limits : bool, default=False
-        If `True`, bypasses TabPFN's built-in limits on dataset size (10000 samples)
-        and feature count (500). **Warning:** Use with caution, as performance is not
-        guaranteed and may be poor when exceeding these limits.
+        If `True`, bypasses the pretraining limits enforced on each TabPFN
+        sub-model. By default (`False`), AutoTabPFN reads the loaded checkpoint's
+        `MAX_NUMBER_OF_SAMPLES` / `MAX_NUMBER_OF_FEATURES` / `MAX_NUMBER_OF_CLASSES`
+        and enforces them through AutoGluon's `max_rows` / `max_features` /
+        `max_classes` guardrails, so the effective limits follow the actual
+        checkpoint capability (v2: 10,000 / 500 / 10; v2.5: 50,000 / 2,000 / 10;
+        v2.6: 100,000 / 2,000 / 10). **Warning:** Use with caution, as performance
+        is not guaranteed and may be poor when exceeding these limits.
 
     Attributes:
     ----------
@@ -137,9 +142,14 @@ class AutoTabPFNBase(BaseEstimator):
 
     def _get_predictor_fit_args(self) -> dict[str, Any]:
         """Constructs the fit arguments for AutoGluon's TabularPredictor."""
+        # Keep verbosity >= 2. At verbosity=1, AutoGluon suppresses the per-sub-model
+        # "Time limit exceeded... Skipping" lines, which are the main signal when no
+        # models complete within `max_time` and the run ends with the unhelpful
+        # `RuntimeError: No models were trained successfully`.
         default_args = {
             "num_bag_folds": 8,
             "fit_weighted_ensemble": True,
+            "verbosity": 2,
         }
         user_args = self.phe_fit_args or {}
         return {**default_args, **user_args}
@@ -323,9 +333,14 @@ class AutoTabPFNClassifier(ClassifierMixin, AutoTabPFNBase):
         Whether to balance the output probabilities from TabPFN. This can be beneficial
         for classification tasks with imbalanced classes.
     ignore_pretraining_limits : bool, default=False
-        If `True`, bypasses TabPFN's built-in limits on dataset size (10000 samples)
-        and feature count (500). **Warning:** Use with caution, as performance is not
-        guaranteed and may be poor when exceeding these limits.
+        If `True`, bypasses the pretraining limits enforced on each TabPFN
+        sub-model. By default (`False`), AutoTabPFN reads the loaded checkpoint's
+        `MAX_NUMBER_OF_SAMPLES` / `MAX_NUMBER_OF_FEATURES` / `MAX_NUMBER_OF_CLASSES`
+        and enforces them through AutoGluon's `max_rows` / `max_features` /
+        `max_classes` guardrails, so the effective limits follow the actual
+        checkpoint capability (v2: 10,000 / 500 / 10; v2.5: 50,000 / 2,000 / 10;
+        v2.6: 100,000 / 2,000 / 10). **Warning:** Use with caution, as performance
+        is not guaranteed and may be poor when exceeding these limits.
 
     Attributes:
     ----------
@@ -476,9 +491,14 @@ class AutoTabPFNRegressor(RegressorMixin, AutoTabPFNBase):
         The number of internal transformers to ensemble within each individual TabPFN model.
         Higher values can improve performance but increase resource usage.
     ignore_pretraining_limits : bool, default=False
-        If `True`, bypasses TabPFN's built-in limits on dataset size (10000 samples)
-        and feature count (500). **Warning:** Use with caution, as performance is not
-        guaranteed and may be poor when exceeding these limits.
+        If `True`, bypasses the pretraining limits enforced on each TabPFN
+        sub-model. By default (`False`), AutoTabPFN reads the loaded checkpoint's
+        `MAX_NUMBER_OF_SAMPLES` / `MAX_NUMBER_OF_FEATURES` / `MAX_NUMBER_OF_CLASSES`
+        and enforces them through AutoGluon's `max_rows` / `max_features` /
+        `max_classes` guardrails, so the effective limits follow the actual
+        checkpoint capability (v2: 10,000 / 500 / 10; v2.5: 50,000 / 2,000 / 10;
+        v2.6: 100,000 / 2,000 / 10). **Warning:** Use with caution, as performance
+        is not guaranteed and may be poor when exceeding these limits.
 
     Attributes:
     ----------

--- a/src/tabpfn_extensions/post_hoc_ensembles/sklearn_interface.py
+++ b/src/tabpfn_extensions/post_hoc_ensembles/sklearn_interface.py
@@ -80,16 +80,8 @@ class AutoTabPFNBase(BaseEstimator):
         The number of internal transformers to ensemble within each individual TabPFN model.
         Higher values can improve performance but increase resource usage.
     ignore_pretraining_limits : bool, default=False
-        If `True`, bypasses the pretraining limits enforced by each TabPFN
-        sub-model. By default (`False`), the wrapped TabPFN raises a
-        `TabPFNValidationError` when the input exceeds the loaded checkpoint's
-        `MAX_NUMBER_OF_SAMPLES` / `MAX_NUMBER_OF_FEATURES` (v2: 10,000 / 500;
-        v2.5: 50,000 / 2,000; v2.6: 100,000 / 2,000). AutoGluon's own
-        `max_rows` / `max_features` / `max_classes` guardrails are always
-        disabled because they hardcode v2-era values and would otherwise clip
-        larger-capacity checkpoints. **Warning:** Use with caution, as
-        performance is not guaranteed and may be poor when exceeding these
-        limits.
+        If `True`, let TabPFN accept inputs that exceed the loaded checkpoint's
+        pretraining limits. Performance is not guaranteed above the limits.
 
     Attributes:
     ----------
@@ -335,16 +327,8 @@ class AutoTabPFNClassifier(ClassifierMixin, AutoTabPFNBase):
         Whether to balance the output probabilities from TabPFN. This can be beneficial
         for classification tasks with imbalanced classes.
     ignore_pretraining_limits : bool, default=False
-        If `True`, bypasses the pretraining limits enforced by each TabPFN
-        sub-model. By default (`False`), the wrapped TabPFN raises a
-        `TabPFNValidationError` when the input exceeds the loaded checkpoint's
-        `MAX_NUMBER_OF_SAMPLES` / `MAX_NUMBER_OF_FEATURES` (v2: 10,000 / 500;
-        v2.5: 50,000 / 2,000; v2.6: 100,000 / 2,000). AutoGluon's own
-        `max_rows` / `max_features` / `max_classes` guardrails are always
-        disabled because they hardcode v2-era values and would otherwise clip
-        larger-capacity checkpoints. **Warning:** Use with caution, as
-        performance is not guaranteed and may be poor when exceeding these
-        limits.
+        If `True`, let TabPFN accept inputs that exceed the loaded checkpoint's
+        pretraining limits. Performance is not guaranteed above the limits.
 
     Attributes:
     ----------
@@ -495,16 +479,8 @@ class AutoTabPFNRegressor(RegressorMixin, AutoTabPFNBase):
         The number of internal transformers to ensemble within each individual TabPFN model.
         Higher values can improve performance but increase resource usage.
     ignore_pretraining_limits : bool, default=False
-        If `True`, bypasses the pretraining limits enforced by each TabPFN
-        sub-model. By default (`False`), the wrapped TabPFN raises a
-        `TabPFNValidationError` when the input exceeds the loaded checkpoint's
-        `MAX_NUMBER_OF_SAMPLES` / `MAX_NUMBER_OF_FEATURES` (v2: 10,000 / 500;
-        v2.5: 50,000 / 2,000; v2.6: 100,000 / 2,000). AutoGluon's own
-        `max_rows` / `max_features` / `max_classes` guardrails are always
-        disabled because they hardcode v2-era values and would otherwise clip
-        larger-capacity checkpoints. **Warning:** Use with caution, as
-        performance is not guaranteed and may be poor when exceeding these
-        limits.
+        If `True`, let TabPFN accept inputs that exceed the loaded checkpoint's
+        pretraining limits. Performance is not guaranteed above the limits.
 
     Attributes:
     ----------

--- a/src/tabpfn_extensions/post_hoc_ensembles/sklearn_interface.py
+++ b/src/tabpfn_extensions/post_hoc_ensembles/sklearn_interface.py
@@ -137,10 +137,10 @@ class AutoTabPFNBase(BaseEstimator):
 
     def _get_predictor_fit_args(self) -> dict[str, Any]:
         """Constructs the fit arguments for AutoGluon's TabularPredictor."""
-        # Keep verbosity >= 2. At verbosity=1, AutoGluon suppresses the per-sub-model
-        # "Time limit exceeded... Skipping" lines, which are the main signal when no
-        # models complete within `max_time` and the run ends with the unhelpful
-        # `RuntimeError: No models were trained successfully`.
+        # Highly suggested to keep verbosity at the AutoGluon default of 2. For
+        # verbosity < 2, important per-model errors are suppressed that make it
+        # hard to understand why AutoTabPFN fails (e.g. if the time budget is
+        # too small).
         default_args = {
             "num_bag_folds": 8,
             "fit_weighted_ensemble": True,

--- a/src/tabpfn_extensions/post_hoc_ensembles/sklearn_interface.py
+++ b/src/tabpfn_extensions/post_hoc_ensembles/sklearn_interface.py
@@ -81,7 +81,8 @@ class AutoTabPFNBase(BaseEstimator):
         Higher values can improve performance but increase resource usage.
     ignore_pretraining_limits : bool, default=False
         If `True`, let TabPFN accept inputs that exceed the loaded checkpoint's
-        pretraining limits. Performance is not guaranteed above the limits.
+        pretraining limits. **Warning:** Use with caution, as performance is
+        not guaranteed and may be poor when exceeding these limits.
 
     Attributes:
     ----------
@@ -328,7 +329,8 @@ class AutoTabPFNClassifier(ClassifierMixin, AutoTabPFNBase):
         for classification tasks with imbalanced classes.
     ignore_pretraining_limits : bool, default=False
         If `True`, let TabPFN accept inputs that exceed the loaded checkpoint's
-        pretraining limits. Performance is not guaranteed above the limits.
+        pretraining limits. **Warning:** Use with caution, as performance is
+        not guaranteed and may be poor when exceeding these limits.
 
     Attributes:
     ----------
@@ -480,7 +482,8 @@ class AutoTabPFNRegressor(RegressorMixin, AutoTabPFNBase):
         Higher values can improve performance but increase resource usage.
     ignore_pretraining_limits : bool, default=False
         If `True`, let TabPFN accept inputs that exceed the loaded checkpoint's
-        pretraining limits. Performance is not guaranteed above the limits.
+        pretraining limits. **Warning:** Use with caution, as performance is
+        not guaranteed and may be poor when exceeding these limits.
 
     Attributes:
     ----------

--- a/src/tabpfn_extensions/post_hoc_ensembles/sklearn_interface.py
+++ b/src/tabpfn_extensions/post_hoc_ensembles/sklearn_interface.py
@@ -246,16 +246,28 @@ class AutoTabPFNBase(BaseEstimator):
                 **self.get_task_args_(),
             }
 
-        def _add_ignore_constraints_inplace(config: dict[str, Any]) -> None:
-            """Add AutoGluon ag_args to bypass training constraints when requested."""
+        def _patch_ag_args_fit_inplace(config: dict[str, Any]) -> None:
+            """Patch AutoGluon's per-model params_aux for TabPFN sub-models.
+
+            - Disable AutoGluon's static max_rows / max_features / max_classes
+              asserts so TabPFN's own per-checkpoint validation is the single
+              authority. TODO: Fix upstream in AutoGluon's `TabPFNV2Model`. A
+              single class handles all v2.x checkpoints with v2-era limits
+              hardcoded in `_get_default_auxiliary_params`, which is wrong for
+              v2.5+. Until that lands, we override per sub-model here.
+            - Forward the user's `ignore_pretraining_limits` flag to TabPFN.
+            """
             ag_args_fit = config.setdefault("ag_args_fit", {})
+            ag_args_fit["max_rows"] = None
+            ag_args_fit["max_features"] = None
+            ag_args_fit["max_classes"] = None
             ag_args_fit["ignore_constraints"] = self.ignore_pretraining_limits
 
         if isinstance(tabpfn_configs, list):
             for cfg in tabpfn_configs:
-                _add_ignore_constraints_inplace(cfg)
+                _patch_ag_args_fit_inplace(cfg)
         else:
-            _add_ignore_constraints_inplace(tabpfn_configs)
+            _patch_ag_args_fit_inplace(tabpfn_configs)
 
         hyperparameters = {TabPFNV2Model: tabpfn_configs}
         if isinstance(self.presets, str) and self.presets == "extreme_quality":

--- a/src/tabpfn_extensions/post_hoc_ensembles/sklearn_interface.py
+++ b/src/tabpfn_extensions/post_hoc_ensembles/sklearn_interface.py
@@ -130,21 +130,22 @@ class AutoTabPFNBase(BaseEstimator):
 
     def _get_predictor_init_args(self) -> dict[str, Any]:
         """Constructs the initialization arguments for AutoGluon's TabularPredictor."""
+        # Don't override AutoGluon's default verbosity (2) — anything lower
+        # suppresses per-model errors that make it hard to understand why
+        # AutoTabPFN fails (e.g. when the time budget is too small, each
+        # sub-model logs "Time limit exceeded... Skipping" at verbosity >= 2
+        # but is silenced at 1, leaving only the generic
+        # `RuntimeError: No models were trained successfully`).
         timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S_%f")
-        default_args = {"verbosity": 1, "path": f"TabPFNModels/m-{timestamp}"}
+        default_args = {"path": f"TabPFNModels/m-{timestamp}"}
         user_args = self.phe_init_args or {}
         return {**default_args, **user_args}
 
     def _get_predictor_fit_args(self) -> dict[str, Any]:
         """Constructs the fit arguments for AutoGluon's TabularPredictor."""
-        # Highly suggested to keep verbosity at the AutoGluon default of 2. For
-        # verbosity < 2, important per-model errors are suppressed that make it
-        # hard to understand why AutoTabPFN fails (e.g. if the time budget is
-        # too small).
         default_args = {
             "num_bag_folds": 8,
             "fit_weighted_ensemble": True,
-            "verbosity": 2,
         }
         user_args = self.phe_fit_args or {}
         return {**default_args, **user_args}

--- a/src/tabpfn_extensions/post_hoc_ensembles/sklearn_interface.py
+++ b/src/tabpfn_extensions/post_hoc_ensembles/sklearn_interface.py
@@ -80,14 +80,16 @@ class AutoTabPFNBase(BaseEstimator):
         The number of internal transformers to ensemble within each individual TabPFN model.
         Higher values can improve performance but increase resource usage.
     ignore_pretraining_limits : bool, default=False
-        If `True`, bypasses the pretraining limits enforced on each TabPFN
-        sub-model. By default (`False`), AutoTabPFN reads the loaded checkpoint's
-        `MAX_NUMBER_OF_SAMPLES` / `MAX_NUMBER_OF_FEATURES` / `MAX_NUMBER_OF_CLASSES`
-        and enforces them through AutoGluon's `max_rows` / `max_features` /
-        `max_classes` guardrails, so the effective limits follow the actual
-        checkpoint capability (v2: 10,000 / 500 / 10; v2.5: 50,000 / 2,000 / 10;
-        v2.6: 100,000 / 2,000 / 10). **Warning:** Use with caution, as performance
-        is not guaranteed and may be poor when exceeding these limits.
+        If `True`, bypasses the pretraining limits enforced by each TabPFN
+        sub-model. By default (`False`), the wrapped TabPFN raises a
+        `TabPFNValidationError` when the input exceeds the loaded checkpoint's
+        `MAX_NUMBER_OF_SAMPLES` / `MAX_NUMBER_OF_FEATURES` (v2: 10,000 / 500;
+        v2.5: 50,000 / 2,000; v2.6: 100,000 / 2,000). AutoGluon's own
+        `max_rows` / `max_features` / `max_classes` guardrails are always
+        disabled because they hardcode v2-era values and would otherwise clip
+        larger-capacity checkpoints. **Warning:** Use with caution, as
+        performance is not guaranteed and may be poor when exceeding these
+        limits.
 
     Attributes:
     ----------
@@ -333,14 +335,16 @@ class AutoTabPFNClassifier(ClassifierMixin, AutoTabPFNBase):
         Whether to balance the output probabilities from TabPFN. This can be beneficial
         for classification tasks with imbalanced classes.
     ignore_pretraining_limits : bool, default=False
-        If `True`, bypasses the pretraining limits enforced on each TabPFN
-        sub-model. By default (`False`), AutoTabPFN reads the loaded checkpoint's
-        `MAX_NUMBER_OF_SAMPLES` / `MAX_NUMBER_OF_FEATURES` / `MAX_NUMBER_OF_CLASSES`
-        and enforces them through AutoGluon's `max_rows` / `max_features` /
-        `max_classes` guardrails, so the effective limits follow the actual
-        checkpoint capability (v2: 10,000 / 500 / 10; v2.5: 50,000 / 2,000 / 10;
-        v2.6: 100,000 / 2,000 / 10). **Warning:** Use with caution, as performance
-        is not guaranteed and may be poor when exceeding these limits.
+        If `True`, bypasses the pretraining limits enforced by each TabPFN
+        sub-model. By default (`False`), the wrapped TabPFN raises a
+        `TabPFNValidationError` when the input exceeds the loaded checkpoint's
+        `MAX_NUMBER_OF_SAMPLES` / `MAX_NUMBER_OF_FEATURES` (v2: 10,000 / 500;
+        v2.5: 50,000 / 2,000; v2.6: 100,000 / 2,000). AutoGluon's own
+        `max_rows` / `max_features` / `max_classes` guardrails are always
+        disabled because they hardcode v2-era values and would otherwise clip
+        larger-capacity checkpoints. **Warning:** Use with caution, as
+        performance is not guaranteed and may be poor when exceeding these
+        limits.
 
     Attributes:
     ----------
@@ -491,14 +495,16 @@ class AutoTabPFNRegressor(RegressorMixin, AutoTabPFNBase):
         The number of internal transformers to ensemble within each individual TabPFN model.
         Higher values can improve performance but increase resource usage.
     ignore_pretraining_limits : bool, default=False
-        If `True`, bypasses the pretraining limits enforced on each TabPFN
-        sub-model. By default (`False`), AutoTabPFN reads the loaded checkpoint's
-        `MAX_NUMBER_OF_SAMPLES` / `MAX_NUMBER_OF_FEATURES` / `MAX_NUMBER_OF_CLASSES`
-        and enforces them through AutoGluon's `max_rows` / `max_features` /
-        `max_classes` guardrails, so the effective limits follow the actual
-        checkpoint capability (v2: 10,000 / 500 / 10; v2.5: 50,000 / 2,000 / 10;
-        v2.6: 100,000 / 2,000 / 10). **Warning:** Use with caution, as performance
-        is not guaranteed and may be poor when exceeding these limits.
+        If `True`, bypasses the pretraining limits enforced by each TabPFN
+        sub-model. By default (`False`), the wrapped TabPFN raises a
+        `TabPFNValidationError` when the input exceeds the loaded checkpoint's
+        `MAX_NUMBER_OF_SAMPLES` / `MAX_NUMBER_OF_FEATURES` (v2: 10,000 / 500;
+        v2.5: 50,000 / 2,000; v2.6: 100,000 / 2,000). AutoGluon's own
+        `max_rows` / `max_features` / `max_classes` guardrails are always
+        disabled because they hardcode v2-era values and would otherwise clip
+        larger-capacity checkpoints. **Warning:** Use with caution, as
+        performance is not guaranteed and may be poor when exceeding these
+        limits.
 
     Attributes:
     ----------

--- a/src/tabpfn_extensions/post_hoc_ensembles/utils.py
+++ b/src/tabpfn_extensions/post_hoc_ensembles/utils.py
@@ -26,8 +26,6 @@ def prepare_tabpfnv2_config(
     - Applies or removes `balance_probabilities`.
     - Handles the special case when `model_type == 'dt_pfn'`.
     - Removes the deprecated `max_depth` key if present.
-    - Disables AutoGluon's v2-era static `max_rows` / `max_features` /
-      `max_classes` guardrails so gating is delegated to TabPFN itself.
 
     Parameters
     ----------
@@ -80,17 +78,6 @@ def prepare_tabpfnv2_config(
 
     # Remove deprecated keys
     config.pop("max_depth", None)
-
-    # Disable AutoGluon's static max_rows / max_features / max_classes asserts
-    # so TabPFN's own per-checkpoint validation is the single authority; user's
-    # `ignore_pretraining_limits` still gates TabPFN itself.
-    #
-    # TODO: Fix this upstream in AutoGluon's `TabPFNV2Model`. A single class
-    # handles all v2.x checkpoints with v2-era limits hardcoded in
-    # `_get_default_auxiliary_params`, which is wrong for v2.5+. Until that
-    # lands, we override per sub-model here.
-    ag_args_fit = config.setdefault("ag_args_fit", {})
-    ag_args_fit.update({"max_rows": None, "max_features": None, "max_classes": None})
 
     return config
 

--- a/src/tabpfn_extensions/post_hoc_ensembles/utils.py
+++ b/src/tabpfn_extensions/post_hoc_ensembles/utils.py
@@ -83,11 +83,12 @@ def prepare_tabpfnv2_config(
 
     # Disable AutoGluon's static max_rows / max_features / max_classes asserts
     # so TabPFN's own per-checkpoint validation is the single authority; user's
-    # `ignore_pretraining_limits` still gates TabPFN itself. Ideally we would
-    # fix this in AutoGluon's `TabPFNV2Model._get_default_auxiliary_params`
-    # (one class handles all v2.x checkpoints, with v2-era limits hardcoded),
-    # but AutoGluon is an external dependency with its own release cycle, so we
-    # override per sub-model here to unblock AutoTabPFN users immediately.
+    # `ignore_pretraining_limits` still gates TabPFN itself.
+    #
+    # TODO: Fix this upstream in AutoGluon's `TabPFNV2Model`. A single class
+    # handles all v2.x checkpoints with v2-era limits hardcoded in
+    # `_get_default_auxiliary_params`, which is wrong for v2.5+. Until that
+    # lands, we override per sub-model here.
     ag_args_fit = config.setdefault("ag_args_fit", {})
     ag_args_fit.update({"max_rows": None, "max_features": None, "max_classes": None})
 

--- a/src/tabpfn_extensions/post_hoc_ensembles/utils.py
+++ b/src/tabpfn_extensions/post_hoc_ensembles/utils.py
@@ -81,14 +81,9 @@ def prepare_tabpfnv2_config(
     # Remove deprecated keys
     config.pop("max_depth", None)
 
-    # AutoGluon's TabPFNv2 integration hardcodes max_rows=10000 /
-    # max_features=500 / max_classes=10 in `_get_default_auxiliary_params`.
-    # These are v2-era values and are wrong for v2.5 (50K / 2000) and v2.6
-    # (100K / 2000). Rather than mirroring them here, we disable the AG-side
-    # checks entirely and let TabPFN's own validation (which knows the actual
-    # loaded checkpoint's `inference_config.MAX_NUMBER_OF_*`) be the single
-    # authority. TabPFN gating itself is still controlled by
-    # `ignore_pretraining_limits` above.
+    # Disable AutoGluon's static max_rows / max_features / max_classes asserts
+    # (v2-era values) so TabPFN's own per-checkpoint validation is the single
+    # authority. User's `ignore_pretraining_limits` still gates TabPFN itself.
     ag_args_fit = config.setdefault("ag_args_fit", {})
     ag_args_fit.update({"max_rows": None, "max_features": None, "max_classes": None})
 

--- a/src/tabpfn_extensions/post_hoc_ensembles/utils.py
+++ b/src/tabpfn_extensions/post_hoc_ensembles/utils.py
@@ -1,59 +1,12 @@
 from __future__ import annotations
 
-import functools
 from typing import Any, Literal
 
 import numpy as np
-import torch
 from hyperopt.pyll import stochastic
 
-from tabpfn.inference_config import InferenceConfig
 from tabpfn.model_loading import ModelVersion
 from tabpfn_extensions.hpo.search_space import get_param_grid_hyperopt
-
-
-@functools.cache
-def _read_ckpt_ag_limits(model_path: str) -> dict[str, int] | None:
-    """Read AutoGluon max_* limits from a TabPFN checkpoint's embedded inference_config.
-
-    Returns a dict of {max_rows, max_features, max_classes}, or None if the
-    checkpoint does not embed an inference_config (v2 and v2.5 do not).
-    """
-    ck = torch.load(model_path, map_location="cpu", weights_only=False)
-    ic = ck.get("inference_config")
-    if isinstance(ic, dict):
-        return {
-            "max_rows": ic["MAX_NUMBER_OF_SAMPLES"],
-            "max_features": ic["MAX_NUMBER_OF_FEATURES"],
-            "max_classes": ic["MAX_NUMBER_OF_CLASSES"],
-        }
-    return None
-
-
-def _get_tabpfn_ag_limits(
-    task_type: Literal["regression", "multiclass"],
-    model_version: ModelVersion,
-    model_path: str,
-) -> dict[str, int]:
-    """Resolve AutoGluon max_rows/max_features/max_classes from the checkpoint.
-
-    Prefer the checkpoint's embedded inference_config (v2.6+); fall back to
-    tabpfn's static defaults via `InferenceConfig.get_default` for v2 and v2.5,
-    where the config is not stored in the checkpoint.
-
-    These values are used as `ag_args` overrides so that AutoGluon's hardcoded
-    defaults for TabPFNv2 (10000 / 500 / 10) do not clip larger-capacity
-    checkpoints.
-    """
-    embedded = _read_ckpt_ag_limits(model_path)
-    if embedded is not None:
-        return embedded
-    cfg = InferenceConfig.get_default(task_type=task_type, model_version=model_version)
-    return {
-        "max_rows": cfg.MAX_NUMBER_OF_SAMPLES,
-        "max_features": cfg.MAX_NUMBER_OF_FEATURES,
-        "max_classes": cfg.MAX_NUMBER_OF_CLASSES,
-    }
 
 
 def prepare_tabpfnv2_config(
@@ -63,7 +16,6 @@ def prepare_tabpfnv2_config(
     ignore_pretraining_limits: bool,
     *,
     refit_folds: bool = True,
-    ag_limits: dict[str, int] | None = None,
 ) -> dict[str, Any]:
     """Prepare a raw TabPFN hyperparameter configuration for TabPFNv2.
 
@@ -74,8 +26,8 @@ def prepare_tabpfnv2_config(
     - Applies or removes `balance_probabilities`.
     - Handles the special case when `model_type == 'dt_pfn'`.
     - Removes the deprecated `max_depth` key if present.
-    - Optionally injects per-checkpoint `max_rows`/`max_features`/`max_classes`
-      overrides into `ag_args` via `ag_limits`.
+    - Disables AutoGluon's v2-era static `max_rows` / `max_features` /
+      `max_classes` guardrails so gating is delegated to TabPFN itself.
 
     Parameters
     ----------
@@ -86,14 +38,9 @@ def prepare_tabpfnv2_config(
     balance_probabilities : Optional[bool]
         If True/False, set for classification; if None, removed (regression).
     ignore_pretraining_limits : bool
-        Whether to bypass default pretraining limits.
+        Whether to bypass default pretraining limits in the wrapped TabPFN.
     refit_folds : bool, optional
         Whether each fold should be refit (default is True).
-    ag_limits : Optional[Dict[str, int]]
-        Per-checkpoint AutoGluon limits (`max_rows`, `max_features`,
-        `max_classes`) to merge into `ag_args_fit`. Overrides the hardcoded
-        10000/500/10 defaults in AutoGluon's TabPFNv2 integration so that
-        larger-capacity checkpoints (v2.5, v2.6) are not artificially capped.
 
     Returns:
     -------
@@ -134,13 +81,16 @@ def prepare_tabpfnv2_config(
     # Remove deprecated keys
     config.pop("max_depth", None)
 
-    # Per-checkpoint AutoGluon limit overrides. AutoGluon's TabPFNv2 integration
-    # hardcodes max_rows=10000 / max_features=500 / max_classes=10 (tuned for v2);
-    # we override via ag_args_fit (AutoGluon's params_aux bucket) so v2.5/v2.6
-    # checkpoints can use their full capacity.
-    if ag_limits is not None:
-        ag_args_fit = config.setdefault("ag_args_fit", {})
-        ag_args_fit.update(ag_limits)
+    # AutoGluon's TabPFNv2 integration hardcodes max_rows=10000 /
+    # max_features=500 / max_classes=10 in `_get_default_auxiliary_params`.
+    # These are v2-era values and are wrong for v2.5 (50K / 2000) and v2.6
+    # (100K / 2000). Rather than mirroring them here, we disable the AG-side
+    # checks entirely and let TabPFN's own validation (which knows the actual
+    # loaded checkpoint's `inference_config.MAX_NUMBER_OF_*`) be the single
+    # authority. TabPFN gating itself is still controlled by
+    # `ignore_pretraining_limits` above.
+    ag_args_fit = config.setdefault("ag_args_fit", {})
+    ag_args_fit.update({"max_rows": None, "max_features": None, "max_classes": None})
 
     return config
 
@@ -195,23 +145,15 @@ def search_space_func(
         task_type=task_type, model_version=model_version
     )
     rng = np.random.default_rng(seed)
-    tabpfn_configs = []
-    for _ in range(n_ensemble_models):
-        raw_config = dict(stochastic.sample(search_space, rng=rng))
-        ag_limits = _get_tabpfn_ag_limits(
-            task_type=task_type,
-            model_version=model_version,
-            model_path=raw_config["model_path"],
+    tabpfn_configs = [
+        prepare_tabpfnv2_config(
+            raw_config=dict(stochastic.sample(search_space, rng=rng)),
+            n_estimators=n_estimators,
+            balance_probabilities=balance_probabilities,
+            ignore_pretraining_limits=ignore_pretraining_limits,
         )
-        tabpfn_configs.append(
-            prepare_tabpfnv2_config(
-                raw_config=raw_config,
-                n_estimators=n_estimators,
-                balance_probabilities=balance_probabilities,
-                ignore_pretraining_limits=ignore_pretraining_limits,
-                ag_limits=ag_limits,
-            )
-        )
+        for _ in range(n_ensemble_models)
+    ]
 
     assert len(tabpfn_configs) > 0
 

--- a/src/tabpfn_extensions/post_hoc_ensembles/utils.py
+++ b/src/tabpfn_extensions/post_hoc_ensembles/utils.py
@@ -1,12 +1,59 @@
 from __future__ import annotations
 
+import functools
 from typing import Any, Literal
 
 import numpy as np
+import torch
 from hyperopt.pyll import stochastic
 
+from tabpfn.inference_config import InferenceConfig
 from tabpfn.model_loading import ModelVersion
 from tabpfn_extensions.hpo.search_space import get_param_grid_hyperopt
+
+
+@functools.lru_cache(maxsize=None)
+def _read_ckpt_ag_limits(model_path: str) -> dict[str, int] | None:
+    """Read AutoGluon max_* limits from a TabPFN checkpoint's embedded inference_config.
+
+    Returns a dict of {max_rows, max_features, max_classes}, or None if the
+    checkpoint does not embed an inference_config (v2 and v2.5 do not).
+    """
+    ck = torch.load(model_path, map_location="cpu", weights_only=False)
+    ic = ck.get("inference_config")
+    if isinstance(ic, dict):
+        return {
+            "max_rows": ic["MAX_NUMBER_OF_SAMPLES"],
+            "max_features": ic["MAX_NUMBER_OF_FEATURES"],
+            "max_classes": ic["MAX_NUMBER_OF_CLASSES"],
+        }
+    return None
+
+
+def _get_tabpfn_ag_limits(
+    task_type: Literal["regression", "multiclass"],
+    model_version: ModelVersion,
+    model_path: str,
+) -> dict[str, int]:
+    """Resolve AutoGluon max_rows/max_features/max_classes from the checkpoint.
+
+    Prefer the checkpoint's embedded inference_config (v2.6+); fall back to
+    tabpfn's static defaults via `InferenceConfig.get_default` for v2 and v2.5,
+    where the config is not stored in the checkpoint.
+
+    These values are used as `ag_args` overrides so that AutoGluon's hardcoded
+    defaults for TabPFNv2 (10000 / 500 / 10) do not clip larger-capacity
+    checkpoints.
+    """
+    embedded = _read_ckpt_ag_limits(model_path)
+    if embedded is not None:
+        return embedded
+    cfg = InferenceConfig.get_default(task_type=task_type, model_version=model_version)
+    return {
+        "max_rows": cfg.MAX_NUMBER_OF_SAMPLES,
+        "max_features": cfg.MAX_NUMBER_OF_FEATURES,
+        "max_classes": cfg.MAX_NUMBER_OF_CLASSES,
+    }
 
 
 def prepare_tabpfnv2_config(
@@ -16,6 +63,7 @@ def prepare_tabpfnv2_config(
     ignore_pretraining_limits: bool,
     *,
     refit_folds: bool = True,
+    ag_limits: dict[str, int] | None = None,
 ) -> dict[str, Any]:
     """Prepare a raw TabPFN hyperparameter configuration for TabPFNv2.
 
@@ -26,6 +74,8 @@ def prepare_tabpfnv2_config(
     - Applies or removes `balance_probabilities`.
     - Handles the special case when `model_type == 'dt_pfn'`.
     - Removes the deprecated `max_depth` key if present.
+    - Optionally injects per-checkpoint `max_rows`/`max_features`/`max_classes`
+      overrides into `ag_args` via `ag_limits`.
 
     Parameters
     ----------
@@ -39,6 +89,11 @@ def prepare_tabpfnv2_config(
         Whether to bypass default pretraining limits.
     refit_folds : bool, optional
         Whether each fold should be refit (default is True).
+    ag_limits : Optional[Dict[str, int]]
+        Per-checkpoint AutoGluon limits (`max_rows`, `max_features`,
+        `max_classes`) to merge into `ag_args`. Overrides the hardcoded
+        10000/500/10 defaults in AutoGluon's TabPFNv2 integration so that
+        larger-capacity checkpoints (v2.5, v2.6) are not artificially capped.
 
     Returns:
     -------
@@ -78,6 +133,13 @@ def prepare_tabpfnv2_config(
 
     # Remove deprecated keys
     config.pop("max_depth", None)
+
+    # Per-checkpoint AutoGluon limit overrides. AutoGluon's TabPFNv2 integration
+    # hardcodes max_rows=10000 / max_features=500 / max_classes=10 (tuned for v2);
+    # we override via ag_args so v2.5/v2.6 checkpoints can use their full capacity.
+    if ag_limits is not None:
+        ag_args = config.setdefault("ag_args", {})
+        ag_args.update(ag_limits)
 
     return config
 
@@ -132,15 +194,23 @@ def search_space_func(
         task_type=task_type, model_version=model_version
     )
     rng = np.random.default_rng(seed)
-    tabpfn_configs = [
-        prepare_tabpfnv2_config(
-            raw_config=dict(stochastic.sample(search_space, rng=rng)),
-            n_estimators=n_estimators,
-            balance_probabilities=balance_probabilities,
-            ignore_pretraining_limits=ignore_pretraining_limits,
+    tabpfn_configs = []
+    for _ in range(n_ensemble_models):
+        raw_config = dict(stochastic.sample(search_space, rng=rng))
+        ag_limits = _get_tabpfn_ag_limits(
+            task_type=task_type,
+            model_version=model_version,
+            model_path=raw_config["model_path"],
         )
-        for _ in range(n_ensemble_models)
-    ]
+        tabpfn_configs.append(
+            prepare_tabpfnv2_config(
+                raw_config=raw_config,
+                n_estimators=n_estimators,
+                balance_probabilities=balance_probabilities,
+                ignore_pretraining_limits=ignore_pretraining_limits,
+                ag_limits=ag_limits,
+            )
+        )
 
     assert len(tabpfn_configs) > 0
 

--- a/src/tabpfn_extensions/post_hoc_ensembles/utils.py
+++ b/src/tabpfn_extensions/post_hoc_ensembles/utils.py
@@ -12,7 +12,7 @@ from tabpfn.model_loading import ModelVersion
 from tabpfn_extensions.hpo.search_space import get_param_grid_hyperopt
 
 
-@functools.lru_cache(maxsize=None)
+@functools.cache
 def _read_ckpt_ag_limits(model_path: str) -> dict[str, int] | None:
     """Read AutoGluon max_* limits from a TabPFN checkpoint's embedded inference_config.
 

--- a/src/tabpfn_extensions/post_hoc_ensembles/utils.py
+++ b/src/tabpfn_extensions/post_hoc_ensembles/utils.py
@@ -82,8 +82,12 @@ def prepare_tabpfnv2_config(
     config.pop("max_depth", None)
 
     # Disable AutoGluon's static max_rows / max_features / max_classes asserts
-    # (v2-era values) so TabPFN's own per-checkpoint validation is the single
-    # authority. User's `ignore_pretraining_limits` still gates TabPFN itself.
+    # so TabPFN's own per-checkpoint validation is the single authority; user's
+    # `ignore_pretraining_limits` still gates TabPFN itself. Ideally we would
+    # fix this in AutoGluon's `TabPFNV2Model._get_default_auxiliary_params`
+    # (one class handles all v2.x checkpoints, with v2-era limits hardcoded),
+    # but AutoGluon is an external dependency with its own release cycle, so we
+    # override per sub-model here to unblock AutoTabPFN users immediately.
     ag_args_fit = config.setdefault("ag_args_fit", {})
     ag_args_fit.update({"max_rows": None, "max_features": None, "max_classes": None})
 

--- a/src/tabpfn_extensions/post_hoc_ensembles/utils.py
+++ b/src/tabpfn_extensions/post_hoc_ensembles/utils.py
@@ -91,7 +91,7 @@ def prepare_tabpfnv2_config(
         Whether each fold should be refit (default is True).
     ag_limits : Optional[Dict[str, int]]
         Per-checkpoint AutoGluon limits (`max_rows`, `max_features`,
-        `max_classes`) to merge into `ag_args`. Overrides the hardcoded
+        `max_classes`) to merge into `ag_args_fit`. Overrides the hardcoded
         10000/500/10 defaults in AutoGluon's TabPFNv2 integration so that
         larger-capacity checkpoints (v2.5, v2.6) are not artificially capped.
 
@@ -136,10 +136,11 @@ def prepare_tabpfnv2_config(
 
     # Per-checkpoint AutoGluon limit overrides. AutoGluon's TabPFNv2 integration
     # hardcodes max_rows=10000 / max_features=500 / max_classes=10 (tuned for v2);
-    # we override via ag_args so v2.5/v2.6 checkpoints can use their full capacity.
+    # we override via ag_args_fit (AutoGluon's params_aux bucket) so v2.5/v2.6
+    # checkpoints can use their full capacity.
     if ag_limits is not None:
-        ag_args = config.setdefault("ag_args", {})
-        ag_args.update(ag_limits)
+        ag_args_fit = config.setdefault("ag_args_fit", {})
+        ag_args_fit.update(ag_limits)
 
     return config
 


### PR DESCRIPTION
## Summary

Motivated by investigating PRI-269 (`AutoTabPFN` silently fails with `RuntimeError: No models were trained successfully`). Three related fixes:

1. **Disable AutoGluon's v2-era static pretraining-limit guardrails for TabPFNv2 sub-models.** AutoGluon's `TabPFNV2Model._get_default_auxiliary_params` hardcodes `max_rows=10000 / max_features=500 / max_classes=10`, tuned for v2. These are wrong for v2.5 (50K / 2000) and v2.6 (100K / 2000). Previously, without `ignore_pretraining_limits=True`, AutoTabPFN would reject any dataset >10K rows *regardless* of which checkpoint was loaded. `prepare_tabpfnv2_config` now sets `ag_args_fit = {"max_rows": None, "max_features": None, "max_classes": None}` — disabling the AG-side asserts entirely and delegating gating to TabPFN's own validation (which knows the actual loaded checkpoint's capability via `inference_config_`). `ignore_pretraining_limits` still controls whether TabPFN enforces or bypasses its own check.

2. **Bump default fit verbosity from the inherited `1` to `2`.** At verbosity=1 AutoGluon suppresses the per-sub-model `Time limit exceeded... Skipping` lines — the only useful signal when the zero-models-trained failure mode fires. Added a comment explaining why the default should not be dropped back to 1.

3. **Fix the unsupported-version error in `hpo/search_space.py`.** The raise had an f-string bug — the second string literal lost its `f` prefix, so `{model_version}` was printed as the literal text instead of being interpolated. Also switched from `ValueError` to `NotImplementedError` — more precise, since no search space has been *defined* for that version rather than the argument being invalid.

Docstrings on the three AutoTabPFN classes updated to describe the new per-checkpoint behavior.

## Test plan

Verified on H100 with 40K × 120 synthetic binary classification at `max_time=60`, no `ignore_pretraining_limits=True`:

- [x] **V2.5 checkpoint (50K limit)**: before → immediate `AssertionError: ag.max_rows=10000 for model 'TabPFNv2_X'`, zero models even attempted, exits in ~10s. After → fit proceeds into AutoGluon's training loop; 60s budget is insufficient on 40K rows so sub-models skip with "Time limit exceeded... Skipping", which is the now-surfaced interpretable diagnostic.
- [x] **V2 checkpoint (10K limit)**: TabPFN's own `TabPFNValidationError` fires cleanly, with a message referencing the *actual* v2 10K limit.
- [x] f-string in `hpo/search_space.py` interpolates `model_version` correctly (and raises `NotImplementedError`).
- [x] CI (full test suite)

## Notes

- `search_space_func` is back to its original shape — no ckpt reads or per-config lookups, so no runtime overhead. AG-side asserts are neutralized with 3 `None` values in `ag_args_fit`; nothing else changes.
- Works regardless of [PriorLabs/TabPFN-private#573](https://github.com/PriorLabs/TabPFN-private/pull/573)'s merge status — we no longer rely on `InferenceConfig.get_default` at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)