### PR TITLE
docs: add Documentation section to README (PRI-278)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Many TabPFN Extensions works with two TabPFN implementations:
 
 Choose the backend that fits your needs - most extensions work with either option!
 
-Exceptions to this are Post Hoc Ensembling and Embeddings, which only work with the local `tabpfn` package.
+Exceptions to this are **post_hoc_ensembles** and **embedding**, which only work with the local `tabpfn` package.
 
 ## Documentation
 
@@ -70,7 +70,7 @@ Documentation for `tabpfn-extensions` is spread across several sources. If you a
 
 ### Examples
 
-Runnable scripts and notebooks for each extension live in the [`examples/`](https://github.com/PriorLabs/tabpfn-extensions/tree/main/examples) directory of this repository:
+Runnable scripts and notebooks for extensions and general use cases live in the [`examples/`](https://github.com/PriorLabs/tabpfn-extensions/tree/main/examples) directory of this repository:
 
 - [`embedding/`](https://github.com/PriorLabs/tabpfn-extensions/tree/main/examples/embedding) — access TabPFN's internal dense sample embeddings
 - [`hpo/`](https://github.com/PriorLabs/tabpfn-extensions/tree/main/examples/hpo) — automatic hyperparameter tuning

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ pip install "tabpfn-extensions[all] @ git+https://github.com/PriorLabs/tabpfn-ex
 - **tabebm**: Data augmentation using TabPFN-based Energy-Based Models
 - **pval_crt**: Statistical feature relevance testing (p-values)
 
-Detailed documentation for each extension is available in the respective module directories.
+See the [Documentation](#documentation) section below for guides, examples, and per-extension READMEs.
 
 ### Backend Options
 
@@ -62,7 +62,52 @@ Many TabPFN Extensions works with two TabPFN implementations:
 
 Choose the backend that fits your needs - most extensions work with either option!
 
-Exceptions to this include Post Hoc Ensembling and Embeddings.
+Exceptions to this are Post Hoc Ensembling and Embeddings, which only work with the local `tabpfn` package.
+
+## Documentation
+
+Documentation for `tabpfn-extensions` is spread across several sources. If you are new to the project, the [examples](#examples) are usually the fastest way to get started; for deeper conceptual guides, see the [TabPFN Docs pages](#tabpfn-docs-pages).
+
+### Examples
+
+Runnable scripts and notebooks for each extension live in the [`examples/`](https://github.com/PriorLabs/tabpfn-extensions/tree/main/examples) directory of this repository:
+
+- [`embedding/`](https://github.com/PriorLabs/tabpfn-extensions/tree/main/examples/embedding) — access TabPFN's internal dense sample embeddings
+- [`hpo/`](https://github.com/PriorLabs/tabpfn-extensions/tree/main/examples/hpo) — automatic hyperparameter tuning
+- [`interpretability/`](https://github.com/PriorLabs/tabpfn-extensions/tree/main/examples/interpretability) — SHAP values, partial dependence plots, feature selection
+- [`large_datasets/`](https://github.com/PriorLabs/tabpfn-extensions/tree/main/examples/large_datasets) — working with datasets beyond TabPFN's default limits
+- [`many_class/`](https://github.com/PriorLabs/tabpfn-extensions/tree/main/examples/many_class) — classification with more than 10 classes
+- [`phe/`](https://github.com/PriorLabs/tabpfn-extensions/tree/main/examples/phe) — post-hoc ensembles
+- [`pval_crt/`](https://github.com/PriorLabs/tabpfn-extensions/tree/main/examples/pval_crt) — statistical feature relevance testing
+- [`rf_pfn/`](https://github.com/PriorLabs/tabpfn-extensions/tree/main/examples/rf_pfn) — TabPFN combined with decision trees and random forests
+- [`survival/`](https://github.com/PriorLabs/tabpfn-extensions/tree/main/examples/survival) — survival analysis
+- [`tabebm/`](https://github.com/PriorLabs/tabpfn-extensions/tree/main/examples/tabebm) — data augmentation via TabEBM
+- [`unsupervised/`](https://github.com/PriorLabs/tabpfn-extensions/tree/main/examples/unsupervised) — data generation, imputation, and outlier detection
+
+### TabPFN Docs pages
+
+In-depth guides for selected extensions are available on [docs.priorlabs.ai](https://docs.priorlabs.ai):
+
+- [Post-hoc ensembles](https://docs.priorlabs.ai/extensions/post-hoc-ensembles)
+- [Many-class](https://docs.priorlabs.ai/extensions/many-class)
+- [HPO](https://docs.priorlabs.ai/extensions/hpo)
+- [RF-PFN](https://docs.priorlabs.ai/extensions/rf-pfn)
+
+### Per-extension READMEs
+
+Some extensions ship a dedicated README alongside their source code:
+
+- [`hpo/`](https://github.com/PriorLabs/tabpfn-extensions/blob/main/src/tabpfn_extensions/hpo/README.md)
+- [`interpretability/`](https://github.com/PriorLabs/tabpfn-extensions/blob/main/src/tabpfn_extensions/interpretability/README.md)
+- [`post_hoc_ensembles/`](https://github.com/PriorLabs/tabpfn-extensions/blob/main/src/tabpfn_extensions/post_hoc_ensembles/README.md)
+- [`pval_crt/`](https://github.com/PriorLabs/tabpfn-extensions/blob/main/src/tabpfn_extensions/pval_crt/README.md)
+- [`tabebm/`](https://github.com/PriorLabs/tabpfn-extensions/blob/main/src/tabpfn_extensions/tabebm/README.md)
+
+### Interactive notebook
+
+The main TabPFN demo notebook also covers several extensions — in particular the [unsupervised](https://github.com/PriorLabs/tabpfn-extensions/tree/main/src/tabpfn_extensions/unsupervised) and [interpretability](https://github.com/PriorLabs/tabpfn-extensions/tree/main/src/tabpfn_extensions/interpretability) extensions:
+
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/PriorLabs/TabPFN/blob/main/examples/notebooks/TabPFN_Demo_Local.ipynb)
 
 ## License
 


### PR DESCRIPTION
## Summary
- Adds a consolidated `## Documentation` section to the main README that references all sources of documentation for `tabpfn-extensions`: the `examples/` directory, the TabPFN-Docs pages (post-hoc ensembles, many-class, HPO, RF-PFN), per-extension READMEs, and the Colab demo notebook.
- Clarifies that Post-Hoc Ensembling and Embeddings only work with the local `tabpfn` package (not the client).

Resolves [PRI-278](https://linear.app/priorlabs/issue/PRI-278/reference-all-the-sources-of-documentation-in-tabpfn-extensions).

## Test plan
- [ ] Review rendered README on GitHub to confirm links resolve and the new section renders cleanly
- [ ] Confirm the per-extension README list matches the set of packages that actually ship a README (`hpo`, `interpretability`, `post_hoc_ensembles`, `pval_crt`, `tabebm`)

## Follow-up (out of scope)
The ticket also asks that the Documentation section in the TabPFN docs site mention this README — that lives in a separate repo and will be handled in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)