### PR TITLE
Release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Widened `tabpfn` dependency cap from `<7` to `<8` (#259). This allows `tabpfn-extensions` to resolve against `tabpfn >= 7.x` (TabPFN v2.6). Fixes the Colab issue where `tabpfn-extensions[all]` transitively pinned `tabpfn` to `6.4.1` (v2.5 model).
-- Standardised random state handling across Random Forest extensions (#235).
+- Standardized random state handling across Random Forest extensions (#235).
 - Added license checks to CI (#238).
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+## [0.3.0] - 2026-04-24
+
+### Added
+- Conditional Randomization Test (CRT) based p-value / hypothesis testing extension using TabPFN (#237).
+- AutoTabPFN diagnostics and per-checkpoint AutoGluon limits (#272, PRI-269).
+
+### Changed
+- Widened `tabpfn` dependency cap from `<7` to `<8` (#259). This allows `tabpfn-extensions` to resolve against `tabpfn >= 7.x` (TabPFN v2.6). Fixes the Colab issue where `tabpfn-extensions[all]` transitively pinned `tabpfn` to `6.4.1` (v2.5 model).
+- Standardised random state handling across Random Forest extensions (#235).
+- Added license checks to CI (#238).
+
+### Removed
+- **BREAKING**: `scikit-survival` is no longer installed by the `[all]` or `[survival]` extras (#269). It is excluded due to its GPL-3.0 license. If you use `SurvivalTabPFN`, install it manually:
+
+  ```
+  pip install scikit-survival
+  ```
+
+  A clear `ImportError` with install instructions is raised when `SurvivalTabPFN` is imported without `scikit-survival` present.
+
+### Fixed
+- Hotfix in the `unsupervised` module (#249).
+- Removed flaky `test_crt_handles_irrelevant_feature` (#256).
+
 ## [0.2.1] - 2025-11-07
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tabpfn-extensions"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
     "torch>=2.1,<3",
     "pandas>=1.4.0,<3",


### PR DESCRIPTION
## Summary

Version bump from `0.2.2` to `0.3.0` plus the corresponding CHANGELOG entry. This is a release-only PR — no code changes.

## Why now

`tabpfn-extensions` on PyPI is stuck at `0.2.2` (2025-11-26). The fix for the tabpfn dependency cap (`<7` → `<8`) landed on main in #259 five weeks ago but has never been released. As a result, the Colab notebook pinned by `README.md` resolves `tabpfn==6.4.1` (v2.5 model) instead of the latest `7.1.1` (v2.6). Cutting 0.3.0 ships the fix.

## Versioning

Bumped as **minor** (`0.3.0`), consistent with the project's SemVer-on-0.x convention and with the `0.1.x → 0.2.0` precedent where widening the tabpfn cap was also a minor bump. Rolls in the breaking `scikit-survival` extras change (#269) under a BREAKING callout in the changelog.

## Changelog highlights

### Added
- CRT extension (#237)
- AutoTabPFN diagnostics + per-checkpoint AutoGluon limits (#272, PRI-269)

### Changed
- Widen `tabpfn<7` → `tabpfn<8` (#259) — **this is the Colab fix**
- Random state standardisation across RF extensions (#235)
- License checks in CI (#238)

### Removed (BREAKING)
- `scikit-survival` removed from `[all]` and `[survival]` extras (#269) — GPL-3.0 license. Install manually if you use `SurvivalTabPFN`; clear `ImportError` at import time otherwise.

### Fixed
- Unsupervised module hotfix (#249)
- Removed flaky `test_crt_handles_irrelevant_feature` (#256)

## Post-merge release steps (manual for this release)

Automated release workflows are a follow-up task for Monday. For this release:

1. Squash-merge this PR.
2. Tag the merge commit: `git tag -a v0.3.0 -m "Release v0.3.0" <sha> && git push origin v0.3.0`.
3. Build: `uv build`.
4. `uvx twine check dist/*`.
5. Dry-run: `uv publish --publish-url https://test.pypi.org/legacy/ --token <testpypi-token>`; verify install from TestPyPI in a fresh venv.
6. Publish to PyPI: `uv publish --token <pypi-token>`.
7. GitHub Release: `gh release create v0.3.0 --title v0.3.0 --notes-file <CHANGELOG section>`.

## Test plan

- [x] Local `uv build` produces `tabpfn_extensions-0.3.0-py3-none-any.whl` with `Requires-Dist: tabpfn<8,>=6.0.5` and passes `twine check`.
- [ ] CI passes (ruff + test matrix).
- [ ] After merge + publish, fresh install of `tabpfn-extensions[all]` + `tabpfn` resolves `tabpfn==7.1.1`, not `6.4.1`.