### PR TITLE
Log space outliers

### DIFF
--- a/src/tabpfn_extensions/unsupervised/experiments.py
+++ b/src/tabpfn_extensions/unsupervised/experiments.py
@@ -187,42 +187,49 @@ class OutlierDetectionUnsupervisedExperiment(Experiment):
     def plot(self):
         # Create a grid of jointplots using PairGrid
         g = sns.PairGrid(self.data, vars=self.feature_names)
-        g.map_upper(sns.scatterplot, s=5, alpha=0.5, hue=self.data["p"])
-        g.map_lower(sns.scatterplot, s=5, alpha=0.5, hue=self.data["p_rank"])
+        g.map_upper(sns.scatterplot, s=5, alpha=0.5, hue=self.data["scores"])
+        g.map_lower(sns.scatterplot, s=5, alpha=0.5, hue=self.data["score_rank"])
         g.add_legend()
 
     def plot_two(self, **kwargs):
-        outlier_thresh_p = kwargs.get("outlier_thresh_p", 0.98)
-        outlier_thresh = np.quantile(
-            self.data["p"][self.data["p"] > 0],
-            outlier_thresh_p,
-        )
+        outlier_thresh_p = kwargs.get("outlier_thresh_p", 0.02)
+        outlier_thresh_p_1 = kwargs.get("outlier_thresh_p_1", 0.1)
 
-        outlier_thresh_p_1 = kwargs.get("outlier_thresh_p_1", 0.9)
-        outlier_thresh_1 = np.quantile(
-            self.data["p"][self.data["p"] > 0],
-            outlier_thresh_p_1,
-        )
+        # np.quantile returns NaN if any rank position falls on -inf (since
+        # interpolation across -inf yields -inf - -inf = NaN). Clamp -inf to
+        # the finite minimum just for the quantile computation; the original
+        # scores series is preserved for bucketing, where x < thresh keeps
+        # -inf rows correctly classified as Low.
+        scores_series = self.data["scores"]
+        finite_mask = np.isfinite(scores_series)
+        if finite_mask.any() and not finite_mask.all():
+            finite_floor = float(scores_series[finite_mask].min())
+            scores_for_quantile = scores_series.where(finite_mask, finite_floor)
+        else:
+            scores_for_quantile = scores_series
+
+        outlier_thresh = np.quantile(scores_for_quantile, outlier_thresh_p)
+        outlier_thresh_1 = np.quantile(scores_for_quantile, outlier_thresh_p_1)
 
         def outlier_f(x, thresh_0, thresh_1):
             if np.isnan(x):
                 return np.nan
-            if x > thresh_0:
-                return f"Low ({round(100 * (1 - outlier_thresh_p), 2)} Percentile)"
-            if x > thresh_1:
-                return f"Medium ({round(100 * (1 - outlier_thresh_p_1), 2)} Percentile)"
+            if x < thresh_0:
+                return f"Low ({round(100 * (outlier_thresh_p), 2)} Percentile)"
+            if x < thresh_1:
+                return f"Medium ({round(100 * (outlier_thresh_p_1), 2)} Percentile)"
             return "High"
 
-        self.data["outlier"] = self.data["p"].map(
+        self.data["outlier"] = self.data["scores"].map(
             partial(outlier_f, thresh_0=outlier_thresh, thresh_1=outlier_thresh_1),
         )
         # Oversample the data with outlier = True
         oversample_low = self.data[
             self.data["outlier"].map(lambda x: "Low" in x)
-        ].sample(frac=1 / (1 - outlier_thresh_p), replace=True)
+        ].sample(frac=1 / (outlier_thresh_p), replace=True)
         oversample_med = self.data[
             self.data["outlier"].map(lambda x: "Medium" in x)
-        ].sample(frac=1 / (1 - outlier_thresh_p_1), replace=True)
+        ].sample(frac=1 / (outlier_thresh_p_1), replace=True)
         data_ = pd.concat(
             [
                 self.data[self.data["outlier"].map(lambda x: "High" in x)],
@@ -230,37 +237,37 @@ class OutlierDetectionUnsupervisedExperiment(Experiment):
                 oversample_med,
             ],
         )
-        g = sns.JointGrid(
+        fig, ax = plt.subplots(figsize=(DEFAULT_HEIGHT, DEFAULT_HEIGHT))
+        sns.scatterplot(
             data=data_,
-            hue="outlier",
             x=self.feature_names[0],
             y=self.feature_names[1],
-            height=DEFAULT_HEIGHT,
+            hue="outlier",
+            s=50,
+            alpha=0.5,
+            ax=ax,
         )
 
-        g.fig.suptitle("Data Density Estimation")
-        g.fig.tight_layout()
-        g.fig.subplots_adjust(top=0.95)  # Reduce plot to make room
+        ax.set_title("outlier detection")
 
-        g.plot_joint(sns.scatterplot, s=50, alpha=0.5)
-        g.plot_marginals(sns.histplot, kde=True, stat="density")
-
-        # Remove the original legend created by plot_joint
-        g.ax_joint.get_legend().remove()
-
-        # Create a new legend on the joint plot axis with no frame and no title
-        handles, labels = g.ax_joint.get_legend_handles_labels()
-        leg = g.ax_joint.legend(
+        ax.get_legend().remove()
+        handles, labels = ax.get_legend_handles_labels()
+        leg = ax.legend(
             handles=handles,
             labels=labels,
-            loc="upper right",
-            title="Estimated density (percentile)",
+            loc="upper left",
+            title="Estimated data log(density)",
+            fontsize="small",
+            title_fontsize="small",
+            borderpad=0.6,
+            handletextpad=0.5,
         )
         leg.get_frame().set_facecolor("white")
         leg.get_frame().set_edgecolor("none")
-        leg.get_frame().set_alpha(1)  # Make the legend background completely opaque
+        leg.get_frame().set_alpha(1)
+        fig.tight_layout()
 
-        return g
+        return ax
 
     def run(
         self,
@@ -291,16 +298,16 @@ class OutlierDetectionUnsupervisedExperiment(Experiment):
             tabpfn.set_categorical_features(categorical_features)
 
             tabpfn.fit(self.X)
-            self.p = tabpfn.outliers(self.X, n_permutations=n_permutations)
+            self.scores = tabpfn.outliers(self.X, n_permutations=n_permutations)
 
-            p_rank = self.p.argsort().argsort()
+            score_rank = self.scores.argsort().argsort()
 
             self.data = pd.DataFrame(
                 torch.cat(
-                    [self.p[:, np.newaxis], p_rank[:, np.newaxis], self.X],
+                    [self.scores[:, np.newaxis], score_rank[:, np.newaxis], self.X],
                     dim=1,
                 ).numpy(),
-                columns=["p", "p_rank", *self.feature_names],
+                columns=["scores", "score_rank", *self.feature_names],
             )
 
             if kwargs.get("should_plot", True):
@@ -312,4 +319,4 @@ class OutlierDetectionUnsupervisedExperiment(Experiment):
                     # Skip plotting if matplotlib is not available
                     pass
 
-            return {"outlier_scores": self.p.numpy()}
+            return {"outlier_scores": self.scores.numpy()}

--- a/src/tabpfn_extensions/unsupervised/experiments.py
+++ b/src/tabpfn_extensions/unsupervised/experiments.py
@@ -187,8 +187,8 @@ class OutlierDetectionUnsupervisedExperiment(Experiment):
     def plot(self):
         # Create a grid of jointplots using PairGrid
         g = sns.PairGrid(self.data, vars=self.feature_names)
-        g.map_upper(sns.scatterplot, s=5, alpha=0.5, hue=self.data["scores"])
-        g.map_lower(sns.scatterplot, s=5, alpha=0.5, hue=self.data["score_rank"])
+        g.map_upper(sns.scatterplot, s=5, alpha=0.5, hue=self.data["log_p"])
+        g.map_lower(sns.scatterplot, s=5, alpha=0.5, hue=self.data["log_p_rank"])
         g.add_legend()
 
     def plot_two(self, **kwargs):
@@ -198,18 +198,18 @@ class OutlierDetectionUnsupervisedExperiment(Experiment):
         # np.quantile returns NaN if any rank position falls on -inf (since
         # interpolation across -inf yields -inf - -inf = NaN). Clamp -inf to
         # the finite minimum just for the quantile computation; the original
-        # scores series is preserved for bucketing, where x < thresh keeps
+        # log_p series is preserved for bucketing, where x < thresh keeps
         # -inf rows correctly classified as Low.
-        scores_series = self.data["scores"]
-        finite_mask = np.isfinite(scores_series)
+        log_p_series = self.data["log_p"]
+        finite_mask = np.isfinite(log_p_series)
         if finite_mask.any() and not finite_mask.all():
-            finite_floor = float(scores_series[finite_mask].min())
-            scores_for_quantile = scores_series.where(finite_mask, finite_floor)
+            finite_floor = float(log_p_series[finite_mask].min())
+            log_p_for_quantile = log_p_series.where(finite_mask, finite_floor)
         else:
-            scores_for_quantile = scores_series
+            log_p_for_quantile = log_p_series
 
-        outlier_thresh = np.quantile(scores_for_quantile, outlier_thresh_p)
-        outlier_thresh_1 = np.quantile(scores_for_quantile, outlier_thresh_p_1)
+        outlier_thresh = np.quantile(log_p_for_quantile, outlier_thresh_p)
+        outlier_thresh_1 = np.quantile(log_p_for_quantile, outlier_thresh_p_1)
 
         def outlier_f(x, thresh_0, thresh_1):
             if np.isnan(x):
@@ -220,7 +220,7 @@ class OutlierDetectionUnsupervisedExperiment(Experiment):
                 return f"Medium ({round(100 * (outlier_thresh_p_1), 2)} Percentile)"
             return "High"
 
-        self.data["outlier"] = self.data["scores"].map(
+        self.data["outlier"] = self.data["log_p"].map(
             partial(outlier_f, thresh_0=outlier_thresh, thresh_1=outlier_thresh_1),
         )
         # Oversample the data with outlier = True
@@ -298,16 +298,16 @@ class OutlierDetectionUnsupervisedExperiment(Experiment):
             tabpfn.set_categorical_features(categorical_features)
 
             tabpfn.fit(self.X)
-            self.scores = tabpfn.outliers(self.X, n_permutations=n_permutations)
+            self.log_p = tabpfn.outliers(self.X, n_permutations=n_permutations)
 
-            score_rank = self.scores.argsort().argsort()
+            log_p_rank = self.log_p.argsort().argsort()
 
             self.data = pd.DataFrame(
                 torch.cat(
-                    [self.scores[:, np.newaxis], score_rank[:, np.newaxis], self.X],
+                    [self.log_p[:, np.newaxis], log_p_rank[:, np.newaxis], self.X],
                     dim=1,
                 ).numpy(),
-                columns=["scores", "score_rank", *self.feature_names],
+                columns=["log_p", "log_p_rank", *self.feature_names],
             )
 
             if kwargs.get("should_plot", True):
@@ -319,4 +319,4 @@ class OutlierDetectionUnsupervisedExperiment(Experiment):
                     # Skip plotting if matplotlib is not available
                     pass
 
-            return {"outlier_scores": self.scores.numpy()}
+            return {"log_p": self.log_p.numpy()}

--- a/src/tabpfn_extensions/unsupervised/unsupervised.py
+++ b/src/tabpfn_extensions/unsupervised/unsupervised.py
@@ -639,8 +639,8 @@ class TabPFNUnsupervisedModel(BaseEstimator):
                 logits_tensor = logits.clone().detach()
                 y_tensor = y_predict.clone().detach().to(logits.device)
                 # criterion.forward returns the NLL, so -forward is log p_θ directly.
-                log_pred = -pred["criterion"].forward(logits_tensor, y_tensor).to(
-                    log_p.device
+                log_pred = (
+                    -pred["criterion"].forward(logits_tensor, y_tensor).to(log_p.device)
                 )
 
             log_p = log_p + log_pred

--- a/src/tabpfn_extensions/unsupervised/unsupervised.py
+++ b/src/tabpfn_extensions/unsupervised/unsupervised.py
@@ -648,7 +648,7 @@ class TabPFNUnsupervisedModel(BaseEstimator):
         return log_p
 
     def outliers_pdf(self, X: torch.Tensor, n_permutations: int = 10) -> torch.Tensor:
-        """Calculate outlier scores from numerical features only.
+        """Calculate the log_pdf from numerical features only.
 
         This method filters out categorical features and only considers numerical features
         for outlier detection.
@@ -658,7 +658,7 @@ class TabPFNUnsupervisedModel(BaseEstimator):
             n_permutations: Number of permutations to use for the outlier calculation
 
         Returns:
-            Outlier scores (lower values indicate more likely outliers).
+            log_pdf (lower values indicate more likely outliers).
         """
         X_store = copy.deepcopy(self.X_)
         mask = torch.ones_like(X_store).bool()
@@ -668,12 +668,12 @@ class TabPFNUnsupervisedModel(BaseEstimator):
         mask[self.categorical_features] = False
         X = X[mask]
 
-        scores_pdf = self.outliers(X, n_permutations=n_permutations)
+        log_pdf = self.outliers(X, n_permutations=n_permutations)
         self.X_ = X_store
-        return scores_pdf
+        return log_pdf
 
     def outliers_pmf(self, X: torch.Tensor, n_permutations: int = 10) -> torch.Tensor:
-        """Calculate outlier scores from categorical features only.
+        """Calculate log_pmf from categorical features only.
 
         This method filters out numerical features and only considers categorical features
         for outlier detection.
@@ -693,9 +693,9 @@ class TabPFNUnsupervisedModel(BaseEstimator):
         mask[self.categorical_features] = True
         X = X[mask]
 
-        scores_pmf = self.outliers(X, n_permutations=n_permutations)
+        log_pmf = self.outliers(X, n_permutations=n_permutations)
         self.X_ = X_store
-        return scores_pmf
+        return log_pmf
 
     @set_extension("unsupervised:outliers")
     def outliers(

--- a/src/tabpfn_extensions/unsupervised/unsupervised.py
+++ b/src/tabpfn_extensions/unsupervised/unsupervised.py
@@ -593,6 +593,7 @@ class TabPFNUnsupervisedModel(BaseEstimator):
         X: torch.tensor,
         feature_permutation: list[int] | tuple[int],
     ) -> torch.tensor:
+        """Compute the chain-rule log-density / log-probability of each row under one permutation."""
         log_p = torch.zeros_like(
             X[:, 0],
         )  # Start with a log probability of 0 (log(1) = 0)
@@ -631,46 +632,33 @@ class TabPFNUnsupervisedModel(BaseEstimator):
                         ):  # Check bounds again per sample
                             # Proper tensor construction to avoid warning
                             pred[idx] = torch.as_tensor(prob_row[y_idx])
+                log_pred = torch.log(pred)
             else:
                 pred = model.predict(X_predict, output_type="full")
-
-                # Get logits tensor properly
                 logits = pred["logits"]
                 logits_tensor = logits.clone().detach()
-
                 y_tensor = y_predict.clone().detach().to(logits.device)
-
-                # TODO: We use 1/pdf here because pdf() returns probability densities that
-                # can be >> 1, causing exp(sum(log(p))) to overflow. Using 1/p keeps values
-                # small and numerically stable. Ideally, refactor to work in log space
-                # throughout and avoid exponentiating altogether.
-                pred = (1.0 / pred["criterion"].pdf(logits_tensor, y_tensor)).to(
+                # criterion.forward returns the NLL, so -forward is log p_θ directly.
+                log_pred = -pred["criterion"].forward(logits_tensor, y_tensor).to(
                     log_p.device
                 )
 
-            # Handle zero or negative probabilities (avoid log(0))
-            pred = torch.clamp(pred, min=1e-10)
-
-            # Convert probabilities to log probabilities
-            log_pred = torch.log(pred)
-
-            # Add log probabilities instead of multiplying probabilities
             log_p = log_p + log_pred
 
-        return log_p, torch.exp(log_p)
+        return log_p
 
     def outliers_pdf(self, X: torch.Tensor, n_permutations: int = 10) -> torch.Tensor:
-        """Calculate outlier scores based on probability density functions for continuous features.
+        """Calculate outlier scores from numerical features only.
 
         This method filters out categorical features and only considers numerical features
-        for outlier detection using probability density functions.
+        for outlier detection.
 
         Args:
             X: Input data tensor
             n_permutations: Number of permutations to use for the outlier calculation
 
         Returns:
-            Tensor of outlier scores (lower values indicate more likely outliers)
+            Outlier scores (lower values indicate more likely outliers).
         """
         X_store = copy.deepcopy(self.X_)
         mask = torch.ones_like(X_store).bool()
@@ -680,15 +668,15 @@ class TabPFNUnsupervisedModel(BaseEstimator):
         mask[self.categorical_features] = False
         X = X[mask]
 
-        pdf = self.outliers(X, n_permutations=n_permutations)
+        scores_pdf = self.outliers(X, n_permutations=n_permutations)
         self.X_ = X_store
-        return pdf
+        return scores_pdf
 
     def outliers_pmf(self, X: torch.Tensor, n_permutations: int = 10) -> torch.Tensor:
-        """Calculate outlier scores based on probability mass functions for categorical features.
+        """Calculate outlier scores from categorical features only.
 
         This method filters out numerical features and only considers categorical features
-        for outlier detection using probability mass functions.
+        for outlier detection.
 
         Args:
             X: Input data tensor
@@ -705,9 +693,9 @@ class TabPFNUnsupervisedModel(BaseEstimator):
         mask[self.categorical_features] = True
         X = X[mask]
 
-        pmf = self.outliers(X, n_permutations=n_permutations)
+        scores_pmf = self.outliers(X, n_permutations=n_permutations)
         self.X_ = X_store
-        return pmf
+        return scores_pmf
 
     @set_extension("unsupervised:outliers")
     def outliers(
@@ -715,12 +703,9 @@ class TabPFNUnsupervisedModel(BaseEstimator):
         X: torch.Tensor | np.ndarray | pd.DataFrame,
         n_permutations: int = 10,
     ) -> torch.Tensor:
-        """Calculate outlier scores for each sample in the input data.
+        """Calculate outlier scores as the log of the arithmetic mean (AM) of the densities across the permutations used to approximate the chain rule.
 
-        This is the preferred implementation for outlier detection, which calculates
-        sample probability for each sample in X by multiplying the probabilities of
-        each feature according to chain rule of probability. Lower probabilities
-        indicate samples that are more likely to be outliers.
+        The logsumexp trick is used to compute the log of the AM to address the risk of over- or underflow.
 
         Parameters:
             X: Union[torch.Tensor, np.ndarray, pd.DataFrame]
@@ -731,8 +716,7 @@ class TabPFNUnsupervisedModel(BaseEstimator):
 
         Returns:
             torch.Tensor:
-                Tensor of outlier scores (lower values indicate more likely outliers),
-                shape (n_samples,)
+                Tensor of outlier scores as log(AM(densities)), (lower values indicate more likely outliers), shape (n_samples,).
 
         Raises:
             RuntimeError: If the model initialization fails
@@ -756,31 +740,18 @@ class TabPFNUnsupervisedModel(BaseEstimator):
         # Use fewer permutations in fast mode
         actual_n_permutations = 1 if fast_mode else n_permutations
 
-        densities: list[torch.Tensor | np.ndarray] = []
+        log_densities: list[torch.Tensor] = []
         for perm in efficient_random_permutation(all_features, actual_n_permutations):
-            perm_density_log, perm_density = self.outliers_single_permutation_(
+            log_p = self.outliers_single_permutation_(
                 X,
                 feature_permutation=perm,
             )
-            densities.append(perm_density)
+            log_densities.append(log_p)
 
-        # Average the densities across all permutations
-        # Handle potential infinite values by replacing them with large finite values
-        densities_clean: list[torch.Tensor] = [
-            torch.nan_to_num(d, nan=0.0, posinf=1e30, neginf=1e-30)
-            if torch.is_tensor(d)
-            else torch.nan_to_num(
-                torch.tensor(d, dtype=torch.float32),
-                nan=0.0,
-                posinf=1e30,
-                neginf=1e-30,
-            )
-            for d in densities
-        ]
-
-        # Stack the clean tensors and compute mean
-        densities_tensor = torch.stack(densities_clean)
-        return densities_tensor.mean(dim=0)
+        # AM combiner via the log-sum-exp identity.
+        return torch.logsumexp(torch.stack(log_densities), dim=0) - np.log(
+            actual_n_permutations
+        )
 
     @set_extension("unsupervised:synthetic")
     def generate_synthetic_data(


### PR DESCRIPTION
## Disclaimer

This document was drafted by AI and reviewed by a human.


## Linked issue

Closes #289 — *Overflow in diffuse density*.


## What changes

Replace `outliers()`'s combiner with the log of the Arythmetic Mean (AM)-via-logsumexp identity. Three coordinated edits in `unsupervised.py`, plus a matching consistency update in `experiments.py`.

### `unsupervised.py`

- **L645** — drop `1.0 /` inversion. The regressor branch reads the log-density directly:
  `log_pred = -pred["criterion"].forward(logits, y_predict).to(log_p.device)`.
The resolved L641–L644 TODO block is removed.
- **L658** — `outliers_single_permutation_` returns `log_p` only.
- **L757–781** — `outliers()` averages densities via the log-sum-exp identity:
  ```python
  return torch.logsumexp(torch.stack(log_densities), dim=0) - np.log(actual_n_permutations)
  ```
  No `nan_to_num` clamps; log-densities don't blow up the way `exp(log_p)` did.
- Docstrings on `outliers()`, `outliers_pdf`, `outliers_pmf`, and the module-level usage example updated to reflect log-density semantics.
- `outliers_pdf` and `outliers_pmf` rename their local variables `pdf`/`pmf` → `log_pdf`/`log_pmf` to reflect the log-density semantics.

### `experiments.py`

`OutlierDetectionUnsupervisedExperiment` is updated to match the new score semantics:

- **Rename**: `self.p` → `self.log_p`, DataFrame column `"p"` → `"log_p"`, rank column `"p_rank"` → `"log_p_rank"`.
- **Polarity flip in `plot_two()`**: threshold tests inverted from `x > thresh` to `x < thresh`. Under the old `1/pdf` combiner, large output meant low joint pdf meant outlier; under `log(AM(pdf))`, low output means outlier — opposite direction. Default percentiles are inverted to match: `outlier_thresh_p` 0.98 → 0.02, `outlier_thresh_p_1` 0.9 → 0.1, with oversampling fractions and legend labels updated accordingly.
- **Drop `[self.data["p"] > 0]` quantile filter, replace with `-inf` clamp**: the old filter was a defensive measure against the old code's `nan_to_num(nan=0.0)` artifacts; under log-density semantics it would silently exclude *all rows where the AM density is < 1*, which is the dominant regime for diffuse predictive PDFs. The replacement: clamp `-inf` rows (zero-pmf categories) to the finite minimum *for the quantile computation only* — `np.quantile` interpolation across `-inf` produces `NaN` (`-inf - -inf`). The original log_p series is preserved for bucketing, where `x < thresh` still classifies `-inf` rows as Low correctly.
- **Plot simplification**: `JointGrid` (joint scatter + marginal histograms) replaced with a plain `scatterplot`.

## ⚠️ Breaking change — MAJOR semver bump

The return type of `outliers()`, `outliers_pdf()`, and `outliers_pmf()` changes from densities to log-densities. Per the project's semver policy in CONTRIBUTING.md, this is a **MAJOR** version bump. We recommend the strictly-breaking change because the old return type encoded the bug; consumers can call `torch.exp(score)` to recover the AM density if they want it.

Public attribute `OutlierDetectionUnsupervisedExperiment.p` is renamed to `log_p`, and the DataFrame columns `"p"` and `"p_rank"` (in the same class's `self.data`) are renamed to `"log_p"` and `"log_p_rank"`. The threshold-test polarity in `plot_two()` is flipped (`x > thresh` → `x < thresh`) — any consumer that was thresholding the old `p` column directly must invert their comparison in addition to renaming. Same MAJOR-bump concern.

## Empirical evidence

Synthetic dataset designed to reproduce overflow (1000 rows, 2 categorical × 9 classes, 5 numerical features as `sign(±) * 10^uniform(-15, +15)`, n_permutations=10, seed=42):

| Metric | Pre-fix | Post-fix |
|---|---|---|
| `min(scores)` | 9.999e+29 | -2.046e+02 |
| `max(scores)` | 1.000e+30 | -1.346e+02 |
| `unique_values` | 2 | 999 |
| `frac_at_ceiling (≥ 1e29)` | 1.0 | 0.0 |
| `flag_rate @ 5th-pct rule` | 0.992 | 0.05 |

The post-fix `flag_rate=0.05` confirms the 5%-percentile contract is honored. `unique_values ≈ N` confirms full per-row resolution (no ties from clamp saturation).

## Test plan

- [x] `pytest tests/test_unsupervised.py` — all 5 pass (2 existing + 3 new)
- [x] `pytest tests/` — full vendor suite passes
- [x] `ruff check src/tabpfn_extensions/unsupervised/` — clean
- [x] `mypy src/tabpfn_extensions/unsupervised/ --python-version=3.10` — clean
- [x] Empirical pre/post-fix reproduction on the same seed=42 synthetic dataset — see table above
