### PR TITLE
docs(examples): multi-output regression + multi-label classification

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -34,15 +34,13 @@ python examples/many_class/many_class_classifier_example.py
    - TabPFN Package - Full PyTorch implementation for local inference
    - TabPFN Client - Lightweight API client for cloud-based inference
 
-3. **Flexible Imports**: Use this pattern for imports to support both backends:
+3. **Imports**: Always import TabPFN classes from `tabpfn_extensions`, which
+   automatically selects the right backend (local `tabpfn` package when
+   available, falling back to `tabpfn_client`):
    ```python
-   try:
-       # Try standard TabPFN package first
-       from tabpfn import TabPFNClassifier, TabPFNRegressor
-   except ImportError:
-       # Fall back to TabPFN client
-       from tabpfn_client import TabPFNClassifier, TabPFNRegressor
+   from tabpfn_extensions import TabPFNClassifier, TabPFNRegressor
    ```
+   No `try/except` boilerplate needed in example files.
 
 4. **Example Datasets**: Use small built-in datasets from scikit-learn. No external data downloads required.
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -9,6 +9,7 @@ examples/
 ├── embedding/         # Access TabPFN's internal dense sample embeddings
 ├── interpretability/  # SHAP, partial dependence, feature selection
 ├── many_class/        # More classes than the checkpoint supports
+├── multioutput/       # Multi-output regression + multi-label classification (sklearn wrapper)
 ├── pval_crt/          # Statistical feature relevance testing
 ├── survival/          # Survival analysis
 ├── tabebm/            # Data augmentation via TabEBM

--- a/examples/multioutput/multioutput_prediction.py
+++ b/examples/multioutput/multioutput_prediction.py
@@ -1,0 +1,61 @@
+"""Multi-output prediction with TabPFN.
+
+TabPFN's classifier/regressor are single-output. For multiple regression
+targets or multi-label classification, wrap TabPFN with sklearn's standard
+``MultiOutputRegressor`` / ``MultiOutputClassifier``. No TabPFN-specific
+wrapper class is needed — this file exists to make that pattern discoverable.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from sklearn.datasets import make_multilabel_classification, make_regression
+from sklearn.metrics import r2_score, roc_auc_score
+from sklearn.model_selection import train_test_split
+from sklearn.multioutput import MultiOutputClassifier, MultiOutputRegressor
+
+from tabpfn_extensions import TabPFNClassifier, TabPFNRegressor
+
+
+# ─────────────────────────── multi-output regression ─────────────────────────
+
+X_reg, y_reg = make_regression(
+    n_samples=120,
+    n_features=6,
+    n_targets=2,
+    n_informative=6,
+    noise=0.05,
+    random_state=0,
+)
+X_tr, X_te, y_tr, y_te = train_test_split(X_reg, y_reg, test_size=0.3, random_state=42)
+
+reg = MultiOutputRegressor(TabPFNRegressor(n_estimators=4))
+reg.fit(X_tr, y_tr)
+y_pred = reg.predict(X_te)
+
+print("Regression predictions shape:", y_pred.shape)
+print("R^2 per target:", [r2_score(y_te[:, i], y_pred[:, i]) for i in range(y_pred.shape[1])])
+print("R^2 (uniform avg):", r2_score(y_te, y_pred, multioutput="uniform_average"))
+
+
+# ─────────────────────────── multi-label classification ──────────────────────
+
+X_clf, y_clf = make_multilabel_classification(
+    n_samples=150,
+    n_features=6,
+    n_classes=3,
+    n_labels=2,
+    allow_unlabeled=False,
+    random_state=1,
+)
+X_clf = X_clf.astype(np.float32)
+X_tr, X_te, y_tr, y_te = train_test_split(X_clf, y_clf, test_size=0.3, random_state=42)
+
+clf = MultiOutputClassifier(TabPFNClassifier(n_estimators=4))
+clf.fit(X_tr, y_tr)
+
+# predict_proba returns a list (one (n_samples, n_classes) array per target).
+# Stack the positive-class probabilities for a micro-ROC-AUC over labels.
+proba = np.stack([p[:, 1] for p in clf.predict_proba(X_te)], axis=1)
+print("Classification proba shape:", proba.shape)
+print("micro-ROC-AUC:", roc_auc_score(y_te, proba, average="micro"))

--- a/examples/multioutput/multioutput_prediction.py
+++ b/examples/multioutput/multioutput_prediction.py
@@ -14,7 +14,12 @@ from sklearn.metrics import r2_score, roc_auc_score
 from sklearn.model_selection import train_test_split
 from sklearn.multioutput import MultiOutputClassifier, MultiOutputRegressor
 
-from tabpfn_extensions import TabPFNClassifier, TabPFNRegressor
+# Flexible imports per examples/README.md — support both the local tabpfn
+# package and the tabpfn-client backend.
+try:
+    from tabpfn import TabPFNClassifier, TabPFNRegressor
+except ImportError:
+    from tabpfn_client import TabPFNClassifier, TabPFNRegressor
 
 
 # ─────────────────────────── multi-output regression ─────────────────────────
@@ -34,7 +39,7 @@ reg.fit(X_tr, y_tr)
 y_pred = reg.predict(X_te)
 
 print("Regression predictions shape:", y_pred.shape)
-print("R^2 per target:", [r2_score(y_te[:, i], y_pred[:, i]) for i in range(y_pred.shape[1])])
+print("R^2 per target:", r2_score(y_te, y_pred, multioutput="raw_values"))
 print("R^2 (uniform avg):", r2_score(y_te, y_pred, multioutput="uniform_average"))
 
 

--- a/examples/multioutput/multioutput_prediction.py
+++ b/examples/multioutput/multioutput_prediction.py
@@ -14,12 +14,7 @@ from sklearn.metrics import r2_score, roc_auc_score
 from sklearn.model_selection import train_test_split
 from sklearn.multioutput import MultiOutputClassifier, MultiOutputRegressor
 
-# Flexible imports per examples/README.md — support both the local tabpfn
-# package and the tabpfn-client backend.
-try:
-    from tabpfn import TabPFNClassifier, TabPFNRegressor
-except ImportError:
-    from tabpfn_client import TabPFNClassifier, TabPFNRegressor
+from tabpfn_extensions import TabPFNClassifier, TabPFNRegressor
 
 
 # ─────────────────────────── multi-output regression ─────────────────────────


### PR DESCRIPTION
## Summary

Adds a small example showing the standard sklearn pattern for multi-output prediction with TabPFN:

```python
MultiOutputRegressor(TabPFNRegressor())
MultiOutputClassifier(TabPFNClassifier())
```

No TabPFN-specific wrapper class — sklearn already handles the multi-output plumbing.

Covers:
- Multi-output regression (R² per target + uniform-average)
- Multi-label classification (micro-ROC-AUC), with a note about the `predict_proba` shape gotcha (`MultiOutputClassifier` returns a list of per-target arrays)

## Why an example instead of a wrapper

This replaces #207, which proposed a dedicated `TabPFNMultiOutput{Regressor,Classifier}` module (~75 lines + `get_params`/`set_params` plumbing) for what's a 2-line user pattern. Per our preference of "examples over extensions where the value-add is thin," moving this to an example makes the pattern discoverable without adding a maintained module surface.

Closes #207.

## Test plan

- [x] Syntax-check the example
- [ ] Run the example end-to-end locally (small data, n_estimators=4) — quick sanity check before merge