### PR TITLE
chore: remove stale classifier_as_regressor references

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ pip install "tabpfn-extensions[all] @ git+https://github.com/PriorLabs/tabpfn-ex
 
 - **interpretability**: Explain TabPFN predictions with SHAP values and feature selection
 - **many_class**: Handle classification problems with more classes than your TabPFN checkpoint supports
-- **classifier_as_regressor**: Use TabPFN's classifier for regression tasks
 - **unsupervised**: Data generation and outlier detection
 - **embedding**: Get TabPFN's internal dense sample embeddings
 - **tabebm**: Data augmentation using TabPFN-based Energy-Based Models

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,6 @@ hpo = [
 # `pip install scikit-survival`. Excluded due to GPL.
 survival = []
 many_class = []
-classifier_as_regressor = []
 unsupervised = []
 
 # Meta-package that installs all extensions


### PR DESCRIPTION
## Summary

The `classifier_as_regressor` module was deleted in #35 (2025-03-21, commit `985dd3b`), but two stale references were left behind:

- `README.md` — the "Available Extensions" list still advertised it as a feature.
- `pyproject.toml` — the empty `classifier_as_regressor = []` install extra.

This PR removes both. No code changes; no impact on anything that imports from the package (since the module is already gone). The install extra was a no-op (empty list) so dropping it has no dependency effect.

Spotted while auditing extension coverage for [PRI-278](https://linear.app/priorlabs/issue/PRI-278/reference-all-the-sources-of-documentation-in-tabpfn-extensions).