### PR TITLE
Fix: drop NaN-target rows from density_ fitting context

### DIFF
--- a/changelog/313.fixed.md
+++ b/changelog/313.fixed.md
@@ -1,0 +1,1 @@
+`TabPFNUnsupervisedModel` imputation/density now fits each column's conditional model only on rows whose target value is observed, instead of keeping rows with a missing target and replacing their label with 0. This removes a bias toward 0 and, when fitting on the same data being imputed, stops the query rows from leaking into their own training context.

--- a/src/tabpfn_extensions/unsupervised/unsupervised.py
+++ b/src/tabpfn_extensions/unsupervised/unsupervised.py
@@ -571,7 +571,7 @@ class TabPFNUnsupervisedModel(BaseEstimator):
         # learn from, so we fall back to the previous behaviour rather than
         # failing the whole call.
         target_observed = ~torch.isnan(X_fit[:, column_idx])
-        if bool(target_observed.any()) and not bool(target_observed.all()):
+        if target_observed.any() and not target_observed.all():
             X_fit = X_fit[target_observed]
 
         if len(conditional_idx) > 0:

--- a/src/tabpfn_extensions/unsupervised/unsupervised.py
+++ b/src/tabpfn_extensions/unsupervised/unsupervised.py
@@ -559,6 +559,21 @@ class TabPFNUnsupervisedModel(BaseEstimator):
         # Initialize model if needed
         self.init_model_and_get_model_config()
 
+        # Only rows whose target column is observed can serve as labeled context
+        # for that column. Rows whose target is NaN carry no usable label: they
+        # were previously kept with a fabricated 0 label (see nan_to_num below),
+        # which biases the fit toward 0 and — when the fit data is the same data
+        # being imputed — leaks the query rows into their own training context.
+        # Dropping them addresses both. This is a no-op when the fit data has no
+        # missing targets (e.g. fitting on complete reference data, the
+        # recommended imputation workflow, or outlier detection on complete
+        # data). If the target column is entirely missing there is no signal to
+        # learn from, so we fall back to the previous behaviour rather than
+        # failing the whole call.
+        target_observed = ~torch.isnan(X_fit[:, column_idx])
+        if bool(target_observed.any()) and not bool(target_observed.all()):
+            X_fit = X_fit[target_observed]
+
         if len(conditional_idx) > 0:
             # If not the first feature, use all previous features
             mask = torch.zeros_like(X_fit).bool()


### PR DESCRIPTION
## What

`TabPFNUnsupervisedModel.density_` builds the labeled context for a column from the entire `self.X_`, replacing NaNs in the target column with `0` (`nan_to_num`). This is a follow-up to #306 review discussion.

Two problems with rows whose **target** column is missing:

1. **Fabricated labels.** Those rows enter the context with a fake `0` label, biasing the conditional fit toward 0 (worse the more of the column is missing).
2. **Query-in-context leakage.** When the fit data *is* the data being imputed (e.g. `fit(X); impute(X)`), the rows being predicted are exactly the NaN-target rows — so the query points sit in their own training context.

## Change

Restrict the labeled context to rows whose **target** column is observed:

```python
target_observed = ~torch.isnan(X_fit[:, column_idx])
if bool(target_observed.any()) and not bool(target_observed.all()):
    X_fit = X_fit[target_observed]
```

Dropping those rows fixes both issues at once (in the fit==impute case the dropped rows *are* the query rows).

## Scope / safety

- **No-op on the recommended path.** When fitting on complete reference data (the documented imputation workflow, see `examples/unsupervised/imputation.py`) or running outlier detection on complete data, no target is NaN, so nothing is dropped.
- Only the **fit==impute-the-same-incomplete-data** case changes behaviour.
- **Degenerate fallback:** if the target column is *entirely* missing there is no signal to learn from, so it falls back to the previous behaviour rather than failing the whole call.
- Conditioning-feature NaNs are untouched — TabPFN handles those natively and the permutation/imputation machinery is meant to deal with them.

## Testing

- Existing `tests/test_unsupervised.py` and `tests/test_unsupervised_dag.py` pass (9 passed).
- Manual end-to-end check: both Case A (fit-on-complete) and Case B (fit==impute) fill all NaNs and preserve shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)