### PR TITLE
chore: remove unused empty test_utils module

### DIFF
--- a/changelog/318.changed.md
+++ b/changelog/318.changed.md
@@ -1,0 +1,1 @@
+Removed the unused, always-empty `test_utils` module from the `tabpfn_extensions` package namespace.

--- a/src/tabpfn_extensions/__init__.py
+++ b/src/tabpfn_extensions/__init__.py
@@ -5,11 +5,9 @@ try:
 except PackageNotFoundError:
     __version__ = "0.1.0.dev0"
 
-# Create alias for test_utils
 # Import third party extensions
 from tabpfn_common_utils.telemetry.interactive import opt_in
 
-from . import test_utils
 from .embedding import TabPFNEmbedding
 from .hpo import TunedTabPFNClassifier, TunedTabPFNRegressor
 from .many_class import ManyClassClassifier
@@ -20,7 +18,6 @@ from .unsupervised import TabPFNUnsupervisedModel
 from .utils import TabPFNClassifier, TabPFNRegressor, is_tabpfn
 
 __all__ = [
-    "test_utils",
     "TabPFNClassifier",
     "TabPFNRegressor",
     "is_tabpfn",


### PR DESCRIPTION
  ## What

  Removes `src/tabpfn_extensions/test_utils.py` and its references in the package `__init__.py`.

  ## Why

  `src/tabpfn_extensions/test_utils.py` has been an empty (0-byte) file since it was
  introduced in 5ee30d1. It is:

  - **Empty** — never contained any code (`git log -p` shows it was added empty and never
    modified).
  - **Never collected as a test** — `pyproject.toml` sets `testpaths = ["tests"]`, and this
    file lives under `src/`, so pytest never discovers it.
  - **Never imported** — a repo-wide search (all file types) finds references *only* in
    `src/tabpfn_extensions/__init__.py`. Nothing in the package, `tests/`, or `examples/`
    imports it.

  It was only re-exported through the package `__init__` as a no-op public attribute.

  ## Changes

  - Delete `src/tabpfn_extensions/test_utils.py`.
  - Remove its three references in `src/tabpfn_extensions/__init__.py`:
    - the `from . import test_utils` import,
    - the `"test_utils"` entry in `__all__`,
    - the now-orphaned `# Create alias for test_utils` comment.
    
  ## Compatibility note

  `test_utils` was listed in `__all__`, so it was technically part of the public namespace.
  Because the module is empty, removing it has no functional effect — there is nothing to
  import from it. Any `from tabpfn_extensions import test_utils` would only ever have bound an
  empty module.