### PR TITLE
ci: add GPU test job (PRI-325)

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -129,6 +129,79 @@ jobs:
           key: model-cache-${{ hashFiles('model_cache/**') }}
           enableCrossOsArchive: true
 
+  test_gpu:
+    name: Test on GPU
+    # Gate only on linting so this runs in parallel with test_compatibility.
+    # The GPU runner is the expensive/scarce tier; linting is a ~seconds-long
+    # cheap guard that avoids spinning it up for obviously broken PRs.
+    needs: check_python_linting
+    timeout-minutes: 30
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - python-version: "3.10"
+            dependency-set: lowest-direct
+          - python-version: "3.13"
+            dependency-set: highest
+
+    runs-on: ubuntu-22.04-4core-gpu
+
+    env:
+      TABPFN_MODEL_CACHE_DIR: ${{ github.workspace }}/model_cache
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync --all-extras --group ci --resolution ${{ matrix.dependency-set }}
+
+      - name: Restore model cache
+        id: restore-model-cache
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ${{ github.workspace }}/model_cache
+          # This cache read will always fail as the model_cache directory is empty.
+          key: model-cache-${{ hashFiles('model_cache/**') }}
+          restore-keys: |
+            model-cache-
+          enableCrossOsArchive: true
+
+      # Download all models fails, if there is a missing model that can't be downloaded.
+      - name: Download models from Hugging Face
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          TABPFN_TOKEN: ${{ secrets.TABPFN_TOKEN }}
+        run: uv run --no-sync python scripts/download_all_models.py
+
+      - name: Run GPU Test Suite
+        env:
+          CUDA_VISIBLE_DEVICES: "0"
+          # Exclude cpu/mps so TabPFN selects the GPU. The cpu code paths are
+          # already covered by the test_compatibility job.
+          TABPFN_EXCLUDE_DEVICES: "cpu,cpu:0,mps"
+        run: |
+          FAST_TEST_MODE=1 uv run --no-sync pytest tests/
+
+      - name: Save model cache
+        if: github.ref == 'refs/heads/main'
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ${{ github.workspace }}/model_cache
+          key: model-cache-${{ hashFiles('model_cache/**') }}
+          enableCrossOsArchive: true
+
   build_verify:
     name: Build wheel + sdist
     runs-on: ubuntu-latest

--- a/changelog/322.added.md
+++ b/changelog/322.added.md
@@ -1,0 +1,1 @@
+Added a GPU CI job (`test_gpu`) that runs the test suite on an `ubuntu-22.04-4core-gpu` runner with CUDA forced, mirroring TabPFN's `test_gpu` job, to give the package GPU code-path coverage.


### PR DESCRIPTION
## Summary

Adds a `test_gpu` job to `pull_request.yml` that runs the existing test suite on an `ubuntu-22.04-4core-gpu` runner with CUDA forced, mirroring TabPFN's [`test_gpu`](<https://github.com/PriorLabs/TabPFN/blob/main/.github/workflows/ci.yml#L309>) job. `tabpfn-extensions` currently has **zero GPU coverage** — every CI run is CPU-only — so device-placement / dtype / CUDA-only-path bugs are invisible today.

Closes [PRI-325](https://linear.app/priorlabs/issue/PRI-325/enable-gpu-tests-for-tabpfn-extensions) (Track A). Track B (run example files in CI, per PriorLabs/tabpfn-extensions#321/PriorLabs/tabpfn-extensions#51) is a separate follow-up — see below.

## What it does

* Separate job (matches how TabPFN / tabpfn-server structure theirs), `runs-on: ubuntu-22.04-4core-gpu`, `timeout-minutes: 30`.
* 2-entry matrix `{3.10 lowest-direct, 3.13 highest}` — extensions' real Python range.
* Forces GPU via `CUDA_VISIBLE_DEVICES=0` + `TABPFN_EXCLUDE_DEVICES=cpu,cpu:0,mps` (cpu paths stay covered by `test_compatibility`).
* `uv sync --all-extras --group ci`; `FAST_TEST_MODE=1 pytest tests/`.
* `needs: check_python_linting` so it runs **in parallel** with `test_compatibility` (≈ +2–3 min wall-clock, not serialized after it).

## Measured (Tesla T4, = the GPU runner class)

<!-- linear:table-colwidths:266,266,266 -->
|  | wall | result |
| -- | -- | -- |
| GPU suite (`FAST_TEST_MODE=1 pytest tests/`) | \~7.8 min | 133 passed / 39 skipped |
| same suite on CPU | \~9.4 min | 133 passed / 39 skipped |

GPU is \~1.2× faster on the compute-heavy tests; tiny-dataset tests are a wash. Main value is coverage, not speed.

## Notes / decisions for review

* **Gating:** `needs: check_python_linting` (parallel) rather than gating behind the CPU test job like TabPFN. Trade-off: faster feedback vs. burning GPU minutes on PRs whose CPU tests would fail. Easy to switch to `needs: test_compatibility` if you prefer the cost fail-fast.
* `FAST_TEST_MODE=1`**:** matches the existing CPU job (and keeps it \~8 min). TabPFN runs the *full* suite on GPU. We can drop fast mode for broader GPU coverage in a follow-up once the runner is confirmed working (full-suite runtime is currently unmeasured).
* **Runner availability:** assumes `ubuntu-22.04-4core-gpu` is granted to this repo (it's used by TabPFN + tabpfn-server). If not, the job will queue rather than fail — worth confirming.

AI was used for assistance.

🤖 Generated with [Claude Code](<https://claude.com/claude-code>)