### PR TITLE
Fix unsupervised experiments marking every feature categorical

### DIFF
--- a/changelog/326.added.md
+++ b/changelog/326.added.md
@@ -1,0 +1,1 @@
+The unsupervised `GenerateSyntheticDataExperiment` and `OutlierDetectionUnsupervisedExperiment` `run()` methods now accept a `categorical_features` argument to designate which columns are categorical, plus a `should_plot` flag to skip plotting.

--- a/changelog/326.fixed.md
+++ b/changelog/326.fixed.md
@@ -1,0 +1,1 @@
+`GenerateSyntheticDataExperiment` and `OutlierDetectionUnsupervisedExperiment` no longer treat every selected feature as categorical, which previously caused numerical columns to be generated as integers.

--- a/examples/unsupervised/generate_mixed_data.py
+++ b/examples/unsupervised/generate_mixed_data.py
@@ -1,0 +1,124 @@
+#  Copyright (c) Prior Labs GmbH 2025.
+#  Licensed under the Apache License, Version 2.0
+
+"""Generate synthetic data for a dataset with categorical and numerical columns.
+
+This example shows how to tell ``GenerateSyntheticDataExperiment`` which columns
+are categorical via the ``categorical_features`` argument, and then checks that the
+generated categorical columns resemble the input: they should not contain category
+values that were absent from the input, and their frequencies should be similar.
+"""
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+from tabpfn_extensions import TabPFNClassifier, TabPFNRegressor
+from tabpfn_extensions.unsupervised import TabPFNUnsupervisedModel
+from tabpfn_extensions.unsupervised.experiments import GenerateSyntheticDataExperiment
+
+
+def make_mixed_dataset(n_samples=400, seed=0):
+    """Build a dataset with two categorical columns and two numerical columns.
+
+    The numerical columns depend on the categorical ones, so there is joint
+    structure for the model to learn.
+    """
+    rng = np.random.default_rng(seed)
+    region = rng.choice([0, 1, 2, 3], size=n_samples, p=[0.45, 0.30, 0.18, 0.07])
+    tier = rng.choice([0, 1, 2], size=n_samples, p=[0.60, 0.30, 0.10])
+    spend = rng.normal(10 + 3 * region, 2.0)
+    age = rng.normal(40 + 5 * tier, 8.0)
+
+    X = np.column_stack([region, tier, spend, age]).astype(np.float32)
+    attribute_names = ["region", "tier", "spend", "age"]
+    categorical_features = [0, 1]
+    return X, attribute_names, categorical_features
+
+
+def report_categorical_fidelity(data, attribute_names, categorical_features):
+    """Print, per categorical column, the input categories and any new ones."""
+    real = data[data["real_or_synthetic"] == "Actual samples"]
+    synthetic = data[data["real_or_synthetic"] == "Generated samples"]
+    for idx in categorical_features:
+        col = attribute_names[idx]
+        real_categories = set(real[col].round().astype(int).unique())
+        synthetic_categories = set(synthetic[col].round().astype(int).unique())
+        novel = sorted(synthetic_categories - real_categories)
+        print(
+            f"{col}: input categories={sorted(real_categories)}, "
+            f"categories in synthetic data not seen in input={novel}",
+        )
+
+
+def plot_real_vs_synthetic(data, attribute_names, categorical_features):
+    """Plot real vs synthetic per column: bars for categorical, histograms otherwise."""
+    real = data[data["real_or_synthetic"] == "Actual samples"]
+    synthetic = data[data["real_or_synthetic"] == "Generated samples"]
+
+    fig, axes = plt.subplots(
+        1, len(attribute_names), figsize=(4 * len(attribute_names), 4)
+    )
+    for idx, (ax, col) in enumerate(zip(axes, attribute_names, strict=True)):
+        if idx in categorical_features:
+            real_freq = real[col].round().astype(int).value_counts(normalize=True)
+            synth_freq = synthetic[col].round().astype(int).value_counts(normalize=True)
+            categories = sorted(set(real_freq.index) | set(synth_freq.index))
+            positions = np.arange(len(categories))
+            width = 0.4
+            ax.bar(
+                positions - width / 2,
+                [real_freq.get(c, 0) for c in categories],
+                width,
+                label="real",
+            )
+            ax.bar(
+                positions + width / 2,
+                [synth_freq.get(c, 0) for c in categories],
+                width,
+                label="synthetic",
+            )
+            ax.set_xticks(positions)
+            ax.set_xticklabels(categories)
+            ax.set_ylabel("frequency")
+        else:
+            ax.hist(real[col], bins=20, density=True, alpha=0.5, label="real")
+            ax.hist(synthetic[col], bins=20, density=True, alpha=0.5, label="synthetic")
+            ax.set_ylabel("density")
+        ax.set_title(col)
+        ax.set_xlabel(col)
+        ax.legend()
+
+    fig.tight_layout()
+    plt.show()
+
+
+def main():
+    X, attribute_names, categorical_features = make_mixed_dataset()
+
+    model_unsupervised = TabPFNUnsupervisedModel(
+        tabpfn_clf=TabPFNClassifier(n_estimators=2),
+        tabpfn_reg=TabPFNRegressor(n_estimators=2),
+    )
+
+    experiment = GenerateSyntheticDataExperiment(task_type="unsupervised")
+    experiment.run(
+        tabpfn=model_unsupervised,
+        X=X,
+        y=np.array([]),
+        attribute_names=attribute_names,
+        indices=list(range(X.shape[1])),
+        categorical_features=categorical_features,
+        n_samples=X.shape[0],
+        should_plot=False,  # we draw our own real-vs-synthetic comparison below
+    )
+
+    print(
+        "Categorical features used by the model:",
+        model_unsupervised.categorical_features,
+    )
+    report_categorical_fidelity(experiment.data, attribute_names, categorical_features)
+    plot_real_vs_synthetic(experiment.data, attribute_names, categorical_features)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/tabpfn_extensions/unsupervised/experiments.py
+++ b/src/tabpfn_extensions/unsupervised/experiments.py
@@ -17,6 +17,28 @@ from tabpfn_extensions.benchmarking import Experiment
 DEFAULT_HEIGHT = 6
 
 
+def _map_categorical_to_subset(categorical_features, indices):
+    """Map categorical column indices (original X space) to selected-subset positions.
+
+    Args:
+        categorical_features: Column indices in the original ``X`` space, or ``None``.
+            Any sequence type (list, tuple, numpy array, torch tensor) is accepted.
+        indices: The selected columns, as a list of ints in subset order.
+
+    Returns:
+        list[int]: Positions within ``indices`` of the selected categorical columns;
+            indices not present in ``indices`` are dropped.
+    """
+    if categorical_features is None:
+        return []
+    subset_position = {col: pos for pos, col in enumerate(indices)}
+    return [
+        subset_position[int(c)]
+        for c in categorical_features
+        if int(c) in subset_position
+    ]
+
+
 class EmbeddingUnsupervisedExperiment(Experiment):
     """This class is used to run experiments on synthetic toy functions."""
 
@@ -100,29 +122,28 @@ class GenerateSyntheticDataExperiment(Experiment):
         g.map_offdiag(sns.scatterplot, s=2, alpha=0.5)
         g.add_legend()
 
-    def run(self, tabpfn, **kwargs):
+    def run(self, tabpfn, *, categorical_features=None, should_plot=True, **kwargs):
         """Generate synthetic data and store it on the experiment instance.
 
         Args:
             tabpfn: A ``TabPFNUnsupervisedModel`` used to learn the joint
                 distribution of the selected features and sample synthetic rows.
+            categorical_features: Column indices of ``X`` (same index space as
+                ``indices``) to treat as categorical. Indices not present in
+                ``indices`` are ignored. Defaults to ``None``, in which case the
+                model auto-detects categorical columns at ``fit`` time.
+            should_plot: Whether to render the pairwise plot. Defaults to ``True``.
             **kwargs: Keyword arguments controlling the run:
                 X: Input data array of shape ``(n_samples, n_features)``.
                 y: Targets (unused for unsupervised generation; may be empty).
                 attribute_names: Column names for every column in ``X``.
                 indices: Column indices of ``X`` to model. Defaults to all columns.
-                categorical_features: Column indices of ``X`` (same index space as
-                    ``indices``) to treat as categorical. Indices not present in
-                    ``indices`` are ignored. Defaults to ``[]``, in which case the
-                    model auto-detects categorical columns at ``fit`` time.
                 temp: Sampling temperature. Defaults to ``1.0``.
                 n_samples: Number of synthetic rows to generate. Defaults to
                     ``X.shape[0]``.
                 n_permutations: Number of feature-order permutations to average.
                     Defaults to ``3``.
                 dag: Optional causal DAG passed to the generator.
-                should_plot: Whether to render the pairwise plot. Defaults to
-                    ``True``.
         """
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
@@ -130,7 +151,7 @@ class GenerateSyntheticDataExperiment(Experiment):
             X, y = copy.deepcopy(kwargs.get("X")), copy.deepcopy(kwargs.get("y"))
             attribute_names = kwargs.get("attribute_names")
 
-            indices = kwargs.get("indices", list(range(X.shape[1])))
+            indices = [int(i) for i in kwargs.get("indices", range(X.shape[1]))]
 
             temp = kwargs.get("temp", 1.0)
             n_samples = kwargs.get("n_samples", X.shape[0])
@@ -140,10 +161,10 @@ class GenerateSyntheticDataExperiment(Experiment):
             self.X, self.y = X, y
             self.X = self.X[:, indices]
             self.feature_names = [attribute_names[i] for i in indices]
-            categorical_features = kwargs.get("categorical_features", [])
-            categorical_features = [
-                indices.index(c) for c in categorical_features if c in indices
-            ]
+            categorical_features = _map_categorical_to_subset(
+                categorical_features,
+                indices,
+            )
             tabpfn.set_categorical_features(categorical_features)
             tabpfn.fit(self.X)
 
@@ -195,7 +216,7 @@ class GenerateSyntheticDataExperiment(Experiment):
                 )
             self.data = pd.concat([self.data_real, self.data_synthetic])
 
-            if kwargs.get("should_plot", True):
+            if should_plot:
                 self.plot()
 
 
@@ -294,6 +315,9 @@ class OutlierDetectionUnsupervisedExperiment(Experiment):
         tabpfn,
         overwrite_baseline_cache=False,
         overwrite_tabpfn_cache=True,
+        *,
+        categorical_features=None,
+        should_plot=True,
         **kwargs,
     ):
         """Estimate per-sample outlier scores for the selected features.
@@ -302,19 +326,18 @@ class OutlierDetectionUnsupervisedExperiment(Experiment):
             tabpfn: A ``TabPFNUnsupervisedModel`` used to estimate sample density.
             overwrite_baseline_cache: Unused placeholder kept for API symmetry.
             overwrite_tabpfn_cache: Unused placeholder kept for API symmetry.
+            categorical_features: Column indices of ``X`` (same index space as
+                ``indices``) to treat as categorical. Indices not present in
+                ``indices`` are ignored. Defaults to ``None``, in which case the
+                model auto-detects categorical columns at ``fit`` time.
+            should_plot: Whether to render the density plot. Defaults to ``True``.
             **kwargs: Keyword arguments controlling the run:
                 X: Input data array of shape ``(n_samples, n_features)``.
                 y: Targets (unused; may be empty).
                 attribute_names: Column names for every column in ``X``.
                 indices: Column indices of ``X`` to model. Defaults to all columns.
-                categorical_features: Column indices of ``X`` (same index space as
-                    ``indices``) to treat as categorical. Indices not present in
-                    ``indices`` are ignored. Defaults to ``[]``, in which case the
-                    model auto-detects categorical columns at ``fit`` time.
                 n_permutations: Number of feature-order permutations to average.
                     Defaults to ``3``.
-                should_plot: Whether to render the density plot. Defaults to
-                    ``True``.
 
         Returns:
             dict: Mapping with key ``"log_p"`` holding the per-sample log-density
@@ -326,16 +349,16 @@ class OutlierDetectionUnsupervisedExperiment(Experiment):
             X, _y = copy.deepcopy(kwargs.get("X")), copy.deepcopy(kwargs.get("y"))
             attribute_names = kwargs.get("attribute_names")
 
-            indices = kwargs.get("indices", list(range(X.shape[1])))
+            indices = [int(i) for i in kwargs.get("indices", range(X.shape[1]))]
             n_permutations = kwargs.get("n_permutations", 3)
 
             self.X = X
             self.X = self.X[:, indices]
             self.feature_names = [attribute_names[i] for i in indices]
-            categorical_features = kwargs.get("categorical_features", [])
-            categorical_features = [
-                indices.index(c) for c in categorical_features if c in indices
-            ]
+            categorical_features = _map_categorical_to_subset(
+                categorical_features,
+                indices,
+            )
             tabpfn.set_categorical_features(categorical_features)
 
             tabpfn.fit(self.X)
@@ -351,7 +374,7 @@ class OutlierDetectionUnsupervisedExperiment(Experiment):
                 columns=["log_p", "log_p_rank", *self.feature_names],
             )
 
-            if kwargs.get("should_plot", True):
+            if should_plot:
                 try:
                     # We don't need to import the module directly here
                     # since plot_two() will do the import

--- a/src/tabpfn_extensions/unsupervised/experiments.py
+++ b/src/tabpfn_extensions/unsupervised/experiments.py
@@ -101,10 +101,28 @@ class GenerateSyntheticDataExperiment(Experiment):
         g.add_legend()
 
     def run(self, tabpfn, **kwargs):
-        """:param tabpfn:
-        :param kwargs:
-            indices: list of indices from X features to use
-        :return:
+        """Generate synthetic data and store it on the experiment instance.
+
+        Args:
+            tabpfn: A ``TabPFNUnsupervisedModel`` used to learn the joint
+                distribution of the selected features and sample synthetic rows.
+            **kwargs: Keyword arguments controlling the run:
+                X: Input data array of shape ``(n_samples, n_features)``.
+                y: Targets (unused for unsupervised generation; may be empty).
+                attribute_names: Column names for every column in ``X``.
+                indices: Column indices of ``X`` to model. Defaults to all columns.
+                categorical_features: Column indices of ``X`` (same index space as
+                    ``indices``) to treat as categorical. Indices not present in
+                    ``indices`` are ignored. Defaults to ``[]``, in which case the
+                    model auto-detects categorical columns at ``fit`` time.
+                temp: Sampling temperature. Defaults to ``1.0``.
+                n_samples: Number of synthetic rows to generate. Defaults to
+                    ``X.shape[0]``.
+                n_permutations: Number of feature-order permutations to average.
+                    Defaults to ``3``.
+                dag: Optional causal DAG passed to the generator.
+                should_plot: Whether to render the pairwise plot. Defaults to
+                    ``True``.
         """
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
@@ -121,13 +139,15 @@ class GenerateSyntheticDataExperiment(Experiment):
 
             self.X, self.y = X, y
             self.X = self.X[:, indices]
-            old_features_names = attribute_names
             self.feature_names = [attribute_names[i] for i in indices]
-            # generate subset of categorical indices
+            # Caller-supplied categorical columns are given in the original X
+            # column space (same space as ``indices``). Translate them to their
+            # position within the selected subset; columns not in ``indices`` are
+            # ignored. When none are supplied, default to [] so that tabpfn.fit()
+            # auto-detects categoricals via infer_categorical_features().
+            categorical_features = kwargs.get("categorical_features", [])
             categorical_features = [
-                self.feature_names.index(name)
-                for name in old_features_names
-                if name in self.feature_names
+                indices.index(c) for c in categorical_features if c in indices
             ]
             tabpfn.set_categorical_features(categorical_features)
             tabpfn.fit(self.X)
@@ -180,7 +200,8 @@ class GenerateSyntheticDataExperiment(Experiment):
                 )
             self.data = pd.concat([self.data_real, self.data_synthetic])
 
-            self.plot()
+            if kwargs.get("should_plot", True):
+                self.plot()
 
 
 class OutlierDetectionUnsupervisedExperiment(Experiment):
@@ -280,6 +301,30 @@ class OutlierDetectionUnsupervisedExperiment(Experiment):
         overwrite_tabpfn_cache=True,
         **kwargs,
     ):
+        """Estimate per-sample outlier scores for the selected features.
+
+        Args:
+            tabpfn: A ``TabPFNUnsupervisedModel`` used to estimate sample density.
+            overwrite_baseline_cache: Unused placeholder kept for API symmetry.
+            overwrite_tabpfn_cache: Unused placeholder kept for API symmetry.
+            **kwargs: Keyword arguments controlling the run:
+                X: Input data array of shape ``(n_samples, n_features)``.
+                y: Targets (unused; may be empty).
+                attribute_names: Column names for every column in ``X``.
+                indices: Column indices of ``X`` to model. Defaults to all columns.
+                categorical_features: Column indices of ``X`` (same index space as
+                    ``indices``) to treat as categorical. Indices not present in
+                    ``indices`` are ignored. Defaults to ``[]``, in which case the
+                    model auto-detects categorical columns at ``fit`` time.
+                n_permutations: Number of feature-order permutations to average.
+                    Defaults to ``3``.
+                should_plot: Whether to render the density plot. Defaults to
+                    ``True``.
+
+        Returns:
+            dict: Mapping with key ``"log_p"`` holding the per-sample log-density
+                (lower values indicate more likely outliers).
+        """
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
 
@@ -291,13 +336,15 @@ class OutlierDetectionUnsupervisedExperiment(Experiment):
 
             self.X = X
             self.X = self.X[:, indices]
-            old_features_names = attribute_names
             self.feature_names = [attribute_names[i] for i in indices]
-            # generate subset of categorical indices
+            # Caller-supplied categorical columns are given in the original X
+            # column space (same space as ``indices``). Translate them to their
+            # position within the selected subset; columns not in ``indices`` are
+            # ignored. When none are supplied, default to [] so that tabpfn.fit()
+            # auto-detects categoricals via infer_categorical_features().
+            categorical_features = kwargs.get("categorical_features", [])
             categorical_features = [
-                self.feature_names.index(name)
-                for name in old_features_names
-                if name in self.feature_names
+                indices.index(c) for c in categorical_features if c in indices
             ]
             tabpfn.set_categorical_features(categorical_features)
 

--- a/src/tabpfn_extensions/unsupervised/experiments.py
+++ b/src/tabpfn_extensions/unsupervised/experiments.py
@@ -140,11 +140,6 @@ class GenerateSyntheticDataExperiment(Experiment):
             self.X, self.y = X, y
             self.X = self.X[:, indices]
             self.feature_names = [attribute_names[i] for i in indices]
-            # Caller-supplied categorical columns are given in the original X
-            # column space (same space as ``indices``). Translate them to their
-            # position within the selected subset; columns not in ``indices`` are
-            # ignored. When none are supplied, default to [] so that tabpfn.fit()
-            # auto-detects categoricals via infer_categorical_features().
             categorical_features = kwargs.get("categorical_features", [])
             categorical_features = [
                 indices.index(c) for c in categorical_features if c in indices
@@ -337,11 +332,6 @@ class OutlierDetectionUnsupervisedExperiment(Experiment):
             self.X = X
             self.X = self.X[:, indices]
             self.feature_names = [attribute_names[i] for i in indices]
-            # Caller-supplied categorical columns are given in the original X
-            # column space (same space as ``indices``). Translate them to their
-            # position within the selected subset; columns not in ``indices`` are
-            # ignored. When none are supplied, default to [] so that tabpfn.fit()
-            # auto-detects categoricals via infer_categorical_features().
             categorical_features = kwargs.get("categorical_features", [])
             categorical_features = [
                 indices.index(c) for c in categorical_features if c in indices

--- a/tests/test_unsupervised_experiments.py
+++ b/tests/test_unsupervised_experiments.py
@@ -136,6 +136,33 @@ def test_generate_synthetic_experiment_translates_original_indices_to_subset():
 
 @pytest.mark.client_compatible
 @pytest.mark.local_compatible
+def test_generate_synthetic_experiment_accepts_array_indices():
+    """Array-typed indices and categorical_features are accepted, not just lists."""
+    X = np.column_stack(
+        [
+            np.random.default_rng(0).normal(size=120),
+            np.repeat(np.arange(4), 30),
+        ],
+    ).astype(np.float32)
+
+    model = _RecordingUnsupervisedModel()
+    experiment = GenerateSyntheticDataExperiment(task_type="unsupervised")
+    experiment.run(
+        tabpfn=model,
+        X=X,
+        y=np.array([]),
+        attribute_names=["numerical", "categorical"],
+        indices=np.array([0, 1]),
+        categorical_features=np.array([1]),
+        n_samples=10,
+        should_plot=False,
+    )
+
+    assert model.categorical_features == [1]
+
+
+@pytest.mark.client_compatible
+@pytest.mark.local_compatible
 def test_outlier_experiment_uses_supplied_categorical_features():
     """OutlierDetection shares the same fix: respect the supplied categorical list."""
     X = torch.tensor(

--- a/tests/test_unsupervised_experiments.py
+++ b/tests/test_unsupervised_experiments.py
@@ -1,0 +1,206 @@
+"""Tests for the unsupervised experiment wrappers in ``experiments.py``.
+
+These cover the categorical-feature handling of ``GenerateSyntheticDataExperiment``
+and ``OutlierDetectionUnsupervisedExperiment`` (regression test for issue #323,
+where every selected feature was force-marked categorical and numerical columns
+were generated as integers).
+
+The fast tests use a lightweight recording stand-in so they need no TabPFN
+weights; one end-to-end test uses a real model under ``FAST_TEST_MODE=1``.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import torch
+
+from tabpfn_extensions import TabPFNClassifier, TabPFNRegressor, unsupervised
+
+# experiments.py imports matplotlib/seaborn at import time; skip the whole module
+# if those optional plotting dependencies are not installed.
+experiments = pytest.importorskip("tabpfn_extensions.unsupervised.experiments")
+GenerateSyntheticDataExperiment = experiments.GenerateSyntheticDataExperiment
+OutlierDetectionUnsupervisedExperiment = (
+    experiments.OutlierDetectionUnsupervisedExperiment
+)
+
+
+class _RecordingUnsupervisedModel:
+    """Stand-in for ``TabPFNUnsupervisedModel`` that needs no TabPFN weights.
+
+    It records the categorical-feature indices the experiment passes to
+    ``set_categorical_features`` so the index-translation logic can be tested in
+    isolation.
+    """
+
+    def __init__(self):
+        self.categorical_features: list[int] = []
+        self._fitted_X = None
+
+    def set_categorical_features(self, categorical_features):
+        self.categorical_features = list(categorical_features)
+
+    def fit(self, X):
+        self._fitted_X = X
+        return self
+
+    def generate_synthetic_data(self, n_samples, t=1.0, n_permutations=3, dag=None):
+        n_features = self._fitted_X.shape[1]
+        return np.random.default_rng(0).normal(size=(n_samples, n_features))
+
+    def outliers(self, X, n_permutations=3):
+        return torch.zeros(X.shape[0], dtype=torch.float32)
+
+
+@pytest.mark.client_compatible
+@pytest.mark.local_compatible
+def test_generate_synthetic_experiment_uses_supplied_categorical_features():
+    """Only the caller-designated column is marked categorical (issue #323)."""
+    X = np.column_stack(
+        [
+            np.repeat(np.arange(4), 30),  # 120 rows, 4 unique -> categorical
+            np.random.default_rng(0).normal(size=120),  # continuous -> numerical
+        ],
+    ).astype(np.float32)
+
+    model = _RecordingUnsupervisedModel()
+    experiment = GenerateSyntheticDataExperiment(task_type="unsupervised")
+    experiment.run(
+        tabpfn=model,
+        X=X,
+        y=np.array([]),
+        attribute_names=["categorical", "numerical"],
+        indices=[0, 1],
+        categorical_features=[0],
+        n_samples=10,
+        should_plot=False,
+    )
+
+    # Previously the experiment force-marked every selected column categorical.
+    assert model.categorical_features == [0]
+
+
+@pytest.mark.client_compatible
+@pytest.mark.local_compatible
+def test_generate_synthetic_experiment_defaults_to_no_categorical_features():
+    """With no override, nothing is force-marked categorical (model auto-detects)."""
+    X = np.column_stack(
+        [
+            np.repeat(np.arange(4), 30),
+            np.random.default_rng(0).normal(size=120),
+        ],
+    ).astype(np.float32)
+
+    model = _RecordingUnsupervisedModel()
+    experiment = GenerateSyntheticDataExperiment(task_type="unsupervised")
+    experiment.run(
+        tabpfn=model,
+        X=X,
+        y=np.array([]),
+        attribute_names=["categorical", "numerical"],
+        indices=[0, 1],
+        n_samples=10,
+        should_plot=False,
+    )
+
+    assert model.categorical_features == []
+
+
+@pytest.mark.client_compatible
+@pytest.mark.local_compatible
+def test_generate_synthetic_experiment_translates_original_indices_to_subset():
+    """categorical_features given in original X space map to the selected subset."""
+    X = np.column_stack(
+        [
+            np.random.default_rng(0).normal(size=120),  # col 0
+            np.random.default_rng(1).normal(size=120),  # col 1 (not selected)
+            np.repeat(np.arange(4), 30),  # col 2 categorical
+        ],
+    ).astype(np.float32)
+
+    model = _RecordingUnsupervisedModel()
+    experiment = GenerateSyntheticDataExperiment(task_type="unsupervised")
+    experiment.run(
+        tabpfn=model,
+        X=X,
+        y=np.array([]),
+        attribute_names=["a", "b", "c"],
+        indices=[2, 0],  # original col 2 lands at subset position 0
+        categorical_features=[2, 1],  # col 1 is not selected -> ignored
+        n_samples=10,
+        should_plot=False,
+    )
+
+    assert model.categorical_features == [0]
+
+
+@pytest.mark.client_compatible
+@pytest.mark.local_compatible
+def test_outlier_experiment_uses_supplied_categorical_features():
+    """OutlierDetection shares the same fix: respect the supplied categorical list."""
+    X = torch.tensor(
+        np.column_stack(
+            [
+                np.repeat(np.arange(4), 30),
+                np.random.default_rng(0).normal(size=120),
+            ],
+        ).astype(np.float32),
+    )
+
+    model = _RecordingUnsupervisedModel()
+    experiment = OutlierDetectionUnsupervisedExperiment(task_type="unsupervised")
+    result = experiment.run(
+        tabpfn=model,
+        X=X,
+        y=torch.zeros(X.shape[0]),
+        attribute_names=["categorical", "numerical"],
+        indices=[0, 1],
+        categorical_features=[0],
+        should_plot=False,
+    )
+
+    assert model.categorical_features == [0]
+    assert "log_p" in result
+
+
+@pytest.mark.client_compatible
+@pytest.mark.local_compatible
+def test_generate_synthetic_experiment_keeps_numerical_features_numerical(monkeypatch):
+    """End-to-end: a numerical column must not be generated as integers (issue #323)."""
+    monkeypatch.setenv("FAST_TEST_MODE", "1")
+
+    rng = np.random.default_rng(0)
+    X = np.column_stack(
+        [
+            np.repeat(np.arange(4), 15),  # 60 rows, 4 unique -> categorical
+            rng.normal(size=60),  # continuous -> numerical
+        ],
+    ).astype(np.float32)
+
+    clf = TabPFNClassifier(n_estimators=1, random_state=0)
+    reg = TabPFNRegressor(n_estimators=1, random_state=0)
+    model = unsupervised.TabPFNUnsupervisedModel(tabpfn_clf=clf, tabpfn_reg=reg)
+
+    experiment = GenerateSyntheticDataExperiment(task_type="unsupervised")
+    experiment.run(
+        tabpfn=model,
+        X=X,
+        y=np.array([]),
+        attribute_names=["categorical", "numerical"],
+        indices=[0, 1],
+        categorical_features=[0],
+        n_samples=20,
+        n_permutations=1,
+        should_plot=False,
+    )
+
+    # The bug marked both columns categorical; the numerical one must stay numerical.
+    assert 0 in model.categorical_features
+    assert 1 not in model.categorical_features
+
+    synthetic = experiment.data[
+        experiment.data["real_or_synthetic"] == "Generated samples"
+    ]
+    numerical = synthetic["numerical"].to_numpy()
+    assert not np.allclose(numerical, np.round(numerical))

--- a/tests/test_unsupervised_experiments.py
+++ b/tests/test_unsupervised_experiments.py
@@ -59,8 +59,8 @@ def test_generate_synthetic_experiment_uses_supplied_categorical_features():
     """Only the caller-designated column is marked categorical (issue #323)."""
     X = np.column_stack(
         [
-            np.repeat(np.arange(4), 30),  # 120 rows, 4 unique -> categorical
-            np.random.default_rng(0).normal(size=120),  # continuous -> numerical
+            np.repeat(np.arange(4), 30),
+            np.random.default_rng(0).normal(size=120),
         ],
     ).astype(np.float32)
 
@@ -77,7 +77,6 @@ def test_generate_synthetic_experiment_uses_supplied_categorical_features():
         should_plot=False,
     )
 
-    # Previously the experiment force-marked every selected column categorical.
     assert model.categorical_features == [0]
 
 
@@ -113,9 +112,9 @@ def test_generate_synthetic_experiment_translates_original_indices_to_subset():
     """categorical_features given in original X space map to the selected subset."""
     X = np.column_stack(
         [
-            np.random.default_rng(0).normal(size=120),  # col 0
-            np.random.default_rng(1).normal(size=120),  # col 1 (not selected)
-            np.repeat(np.arange(4), 30),  # col 2 categorical
+            np.random.default_rng(0).normal(size=120),
+            np.random.default_rng(1).normal(size=120),
+            np.repeat(np.arange(4), 30),
         ],
     ).astype(np.float32)
 
@@ -126,8 +125,8 @@ def test_generate_synthetic_experiment_translates_original_indices_to_subset():
         X=X,
         y=np.array([]),
         attribute_names=["a", "b", "c"],
-        indices=[2, 0],  # original col 2 lands at subset position 0
-        categorical_features=[2, 1],  # col 1 is not selected -> ignored
+        indices=[2, 0],
+        categorical_features=[2, 1],
         n_samples=10,
         should_plot=False,
     )
@@ -173,8 +172,8 @@ def test_generate_synthetic_experiment_keeps_numerical_features_numerical(monkey
     rng = np.random.default_rng(0)
     X = np.column_stack(
         [
-            np.repeat(np.arange(4), 15),  # 60 rows, 4 unique -> categorical
-            rng.normal(size=60),  # continuous -> numerical
+            np.repeat(np.arange(4), 15),
+            rng.normal(size=60),
         ],
     ).astype(np.float32)
 
@@ -195,7 +194,6 @@ def test_generate_synthetic_experiment_keeps_numerical_features_numerical(monkey
         should_plot=False,
     )
 
-    # The bug marked both columns categorical; the numerical one must stay numerical.
     assert 0 in model.categorical_features
     assert 1 not in model.categorical_features
 

--- a/tests/test_unsupervised_experiments.py
+++ b/tests/test_unsupervised_experiments.py
@@ -1,9 +1,8 @@
 """Tests for the unsupervised experiment wrappers in ``experiments.py``.
 
 These cover the categorical-feature handling of ``GenerateSyntheticDataExperiment``
-and ``OutlierDetectionUnsupervisedExperiment`` (regression test for issue #323,
-where every selected feature was force-marked categorical and numerical columns
-were generated as integers).
+and ``OutlierDetectionUnsupervisedExperiment``: only caller-designated columns are
+treated as categorical, and numerical columns are generated as floats.
 
 The fast tests use a lightweight recording stand-in so they need no TabPFN
 weights; one end-to-end test uses a real model under ``FAST_TEST_MODE=1``.
@@ -56,7 +55,7 @@ class _RecordingUnsupervisedModel:
 @pytest.mark.client_compatible
 @pytest.mark.local_compatible
 def test_generate_synthetic_experiment_uses_supplied_categorical_features():
-    """Only the caller-designated column is marked categorical (issue #323)."""
+    """Only the caller-designated column is marked categorical."""
     X = np.column_stack(
         [
             np.repeat(np.arange(4), 30),
@@ -193,7 +192,7 @@ def test_outlier_experiment_uses_supplied_categorical_features():
 @pytest.mark.client_compatible
 @pytest.mark.local_compatible
 def test_generate_synthetic_experiment_keeps_numerical_features_numerical(monkeypatch):
-    """End-to-end: a numerical column must not be generated as integers (issue #323)."""
+    """End-to-end: a numerical column must not be generated as integers."""
     monkeypatch.setenv("FAST_TEST_MODE", "1")
 
     rng = np.random.default_rng(0)


### PR DESCRIPTION
GenerateSyntheticDataExperiment and OutlierDetectionUnsupervisedExperiment computed categorical indices with a comprehension that always evaluated to [0, 1, ..., n-1], so every selected feature was force-marked categorical and numerical columns were generated as integers (issue #323). There was also no way for a caller to specify which features are categorical.

Replace the broken comprehension in both experiments with a `categorical_features` kwarg (indices in the original X column space, same as `indices`), translated to the selected-subset position. When omitted it defaults to [] so the model's existing infer_categorical_features auto-detection runs at fit time. Also add a `should_plot=True` guard to GenerateSyntheticDataExperiment so data-only/headless callers can skip the forced plot, and document the kwargs.

Add tests/test_unsupervised_experiments.py covering the index translation, the default-empty behavior, and an end-to-end check that numerical columns are generated as floats.

Fixes #323