### PR TITLE
ci: skip changelog check for dependabot PRs (by branch prefix)

### DIFF
--- a/.github/workflows/check-changelog.yml
+++ b/.github/workflows/check-changelog.yml
@@ -15,7 +15,7 @@ jobs:
     name: Changelog entry
     if: >-
       github.event_name == 'pull_request' &&
-      github.actor != 'dependabot[bot]' &&
+      !startsWith(github.head_ref, 'dependabot/') &&
       !startsWith(github.head_ref, 'release/v')
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
### Problem
The `Changelog entry` check fails on dependabot PRs like #319, even though dependabot bumps shouldn't need a changelog. The job already *tried* to skip dependabot:

```yaml
github.actor != 'dependabot[bot]'
```

but `github.actor` is **whoever triggers the run**, not the PR author. On #319 the failing run shows `actor: noahho` (a maintainer re-ran / interacted with the PR), so the guard passed, the job ran, and it failed on the missing changelog. Any human interaction with a dependabot PR (re-run, label, rebase) reintroduces the failure.

### Fix
Gate on the PR head branch prefix instead, which is stable regardless of who triggers the run - mirroring the existing `release/v` skip:

```yaml
!startsWith(github.head_ref, 'dependabot/')
```

Dependabot branches are always `dependabot/...`, so the changelog job is now reliably skipped for them.

### Effect
- Dependabot PRs (e.g. #319) no longer require a changelog entry.
- Human PRs still require one; `release/v*` branches still skipped.

Note: if `Changelog entry` is a required status check in branch protection, a skipped job reports success, so #319 should go green once this merges (it may need a re-run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)