### PR TITLE
add simple imputation method (PRI-313)

### DIFF
--- a/changelog/335.added.md
+++ b/changelog/335.added.md
@@ -1,0 +1,1 @@
+Add `simple_impute`, a fast, lightweight column-by-column missing-value imputer in `unsupervised` — a single-pass alternative to `TabPFNUnsupervisedModel.impute()`.

--- a/examples/unsupervised/imputation.py
+++ b/examples/unsupervised/imputation.py
@@ -75,3 +75,25 @@ original_values = X_test[original_nan_mask]
 
 mse = np.mean((imputed_values - original_values) ** 2)
 print(f"Mean Squared Error of imputed values vs. original values: {mse:.4f}")
+
+# --- 6. Alternative: the simple, transductive imputer ---
+# `simple_impute` is a lightweight alternative that needs no separate fit step.
+# For each column with missing values it fits a TabPFN model on the rows where
+# that column is observed (using all other columns as features) and predicts the
+# missing rows. Here we hand it the training rows stacked on top of the test rows
+# so it has the (complete) training data as additional context.
+# thus when predicting each column it can have a larger context and thus
+# higher accuracy
+
+from tabpfn_extensions.unsupervised import simple_impute
+
+print("\nImputing the same data with simple_impute...")
+X_merged_missing = np.vstack([X_train, X_test_missing])
+X_merged_imputed = simple_impute(X_merged_missing, tabpfn_reg=reg, tabpfn_clf=clf)
+
+# Recover the imputed test rows and score them the same way as above.
+X_test_imputed_simple = X_merged_imputed[len(X_train) :]
+imputed_values_simple = X_test_imputed_simple[original_nan_mask]
+
+mse_simple = np.mean((imputed_values_simple - original_values) ** 2)
+print(f"[simple_impute] Mean Squared Error vs. original values: {mse_simple:.4f}")

--- a/examples/unsupervised/imputation.py
+++ b/examples/unsupervised/imputation.py
@@ -80,7 +80,7 @@ model_unsupervised.fit(X_train)
 print("Imputing missing values by sampling from the model...")
 X_imputed_tensor = model_unsupervised.impute(
     X_test_missing,
-    n_permutations=5,  # Fewer permutations for a quicker example
+    n_permutations=1,  # Model uses n_estimators=8 by default
 )
 
 n_missing_after = torch.isnan(X_imputed_tensor).sum().item()

--- a/examples/unsupervised/imputation.py
+++ b/examples/unsupervised/imputation.py
@@ -7,6 +7,7 @@ from sklearn.datasets import load_breast_cancer
 from sklearn.model_selection import train_test_split
 
 from tabpfn_extensions import TabPFNClassifier, TabPFNRegressor, unsupervised
+from tabpfn_extensions.unsupervised import simple_impute
 
 # --- 1. Load and Prepare Data ---
 # Load the breast cancer dataset
@@ -36,64 +37,55 @@ for col_idx in range(3):
 
 print(f"Introduced {np.isnan(X_test_missing).sum()} missing values into the test set.")
 
-# --- 3. Initialize the Unsupervised Model ---
-# Initialize TabPFN models for regression and classification tasks.
-# The unsupervised model uses these to model the data distribution.
+# Keep the ground-truth values of the injected cells so we can score the result.
+original_nan_mask = np.isnan(X_test_missing)
+original_values = X_test[original_nan_mask]
+
+# Initialize TabPFN models for the regression and classification sub-problems that
+# imputation is built on.
 clf = TabPFNClassifier(n_estimators=3)
 reg = TabPFNRegressor(n_estimators=3)
 
-# Initialize the main unsupervised model
+# --- 3. Impute Missing Values ---
+# `simple_impute` fills in missing values one column at a time: for each column
+# that has NaNs it fits a TabPFN model on the rows where that column is observed,
+# using all the other columns as features, and predicts the rows where it is
+# missing. It works directly on a single table, so we stack the (complete)
+# training rows with the test rows to give every column as much context as
+# possible when it is predicted.
+print("\nImputing missing values...")
+X_all = np.vstack([X_train, X_test_missing])
+X_all_imputed = simple_impute(X_all, tabpfn_reg=reg, tabpfn_clf=clf)
+
+# Pull the imputed test rows back out and score them against the ground truth.
+X_test_imputed = X_all_imputed[len(X_train) :]
+imputed_values = X_test_imputed[original_nan_mask]
+
+mse = np.mean((imputed_values - original_values) ** 2)
+print(f"Imputation complete. Mean Squared Error vs. original values: {mse:.4f}")
+
+# --- 4. Density-based imputation with TabPFNUnsupervisedModel ---
+# When you need to *sample* imputations (rather than take the best estimate), or
+# to condition on a causal DAG, TabPFNUnsupervisedModel models the joint
+# distribution: it fits a reference set and imputes by averaging over random
+# feature permutations and sampling from the resulting density.
 model_unsupervised = unsupervised.TabPFNUnsupervisedModel(
     tabpfn_clf=clf,
     tabpfn_reg=reg,
 )
 
-# --- 4. Fit and Impute ---
-# Fit the model on the complete training data (without missing values)
-print("Fitting the unsupervised model on the training data...")
+print("\nFitting TabPFNUnsupervisedModel on the training data...")
 model_unsupervised.fit(X_train)
 
-# Perform imputation on the test set
-print("Imputing missing values...")
+print("Imputing missing values by sampling from the model...")
 X_imputed_tensor = model_unsupervised.impute(
     X_test_missing,
     n_permutations=5,  # Fewer permutations for a quicker example
 )
 
-# --- 5. Verify Results ---
-# Check that the imputed data no longer contains any NaN values
 n_missing_after = torch.isnan(X_imputed_tensor).sum().item()
+print(f"Number of missing values after imputation: {n_missing_after}")
 
-print(f"\nNumber of missing values after imputation: {n_missing_after}")
-print(f"Imputation complete. Shape of imputed data: {X_imputed_tensor.shape}")
-
-# Optional: Calculate the Mean Squared Error for the imputed values,
-# since we know the original ground truth values.
-original_nan_mask = np.isnan(X_test_missing)
-imputed_values = X_imputed_tensor.numpy()[original_nan_mask]
-original_values = X_test[original_nan_mask]
-
-mse = np.mean((imputed_values - original_values) ** 2)
-print(f"Mean Squared Error of imputed values vs. original values: {mse:.4f}")
-
-# --- 6. Alternative: the simple, transductive imputer ---
-# `simple_impute` is a lightweight alternative that needs no separate fit step.
-# For each column with missing values it fits a TabPFN model on the rows where
-# that column is observed (using all other columns as features) and predicts the
-# missing rows. Here we hand it the training rows stacked on top of the test rows
-# so it has the (complete) training data as additional context.
-# thus when predicting each column it can have a larger context and thus
-# higher accuracy
-
-from tabpfn_extensions.unsupervised import simple_impute
-
-print("\nImputing the same data with simple_impute...")
-X_merged_missing = np.vstack([X_train, X_test_missing])
-X_merged_imputed = simple_impute(X_merged_missing, tabpfn_reg=reg, tabpfn_clf=clf)
-
-# Recover the imputed test rows and score them the same way as above.
-X_test_imputed_simple = X_merged_imputed[len(X_train) :]
-imputed_values_simple = X_test_imputed_simple[original_nan_mask]
-
-mse_simple = np.mean((imputed_values_simple - original_values) ** 2)
-print(f"[simple_impute] Mean Squared Error vs. original values: {mse_simple:.4f}")
+imputed_values_density = X_imputed_tensor.numpy()[original_nan_mask]
+mse_density = np.mean((imputed_values_density - original_values) ** 2)
+print(f"Mean Squared Error vs. original values: {mse_density:.4f}")

--- a/src/tabpfn_extensions/unsupervised/__init__.py
+++ b/src/tabpfn_extensions/unsupervised/__init__.py
@@ -3,6 +3,7 @@
 #  Copyright (c) Prior Labs GmbH 2025.
 #  Licensed under the Apache License, Version 2.0
 
+from .simple_impute import impute_column, simple_impute
 from .unsupervised import TabPFNUnsupervisedModel
 
-__all__ = ["TabPFNUnsupervisedModel"]
+__all__ = ["TabPFNUnsupervisedModel", "impute_column", "simple_impute"]

--- a/src/tabpfn_extensions/unsupervised/simple_impute.py
+++ b/src/tabpfn_extensions/unsupervised/simple_impute.py
@@ -65,9 +65,13 @@ def impute_column(
     Returns:
         np.ndarray: ``X`` with column ``col`` filled (mutated in place and returned).
     """
-    features = [c for c in range(X.shape[1]) if c != col]
     missing = np.isnan(X[:, col])
+    if not missing.any():
+        return X
+    if missing.all():
+        raise ValueError(f"Column {col} is entirely NaN and cannot be imputed.")
 
+    features = [c for c in range(X.shape[1]) if c != col]
     # context = rows where the target column is observed (real labels)
     # query   = rows where the target column is missing
     X_ctx, y_ctx = X[~missing][:, features], X[~missing, col]

--- a/src/tabpfn_extensions/unsupervised/simple_impute.py
+++ b/src/tabpfn_extensions/unsupervised/simple_impute.py
@@ -1,0 +1,137 @@
+#  Copyright (c) Prior Labs GmbH 2025.
+#  Licensed under the Apache License, Version 2.0
+
+"""Simple, transductive missing-value imputation with TabPFN.
+
+A lightweight alternative to :class:`TabPFNUnsupervisedModel.impute` that models
+each column the canonical way: treat the column being imputed as the target and
+*every other column* as features (missing values in those feature columns are
+left in place — TabPFN handles NaNs natively), fit on the rows where the target
+is observed, and predict the rows where it is missing.
+
+Unlike the permutation-ensembled approach in :mod:`unsupervised`, this does a
+single ``fit`` + ``predict`` per column with missing values. It is transductive:
+it takes one table and figures out reference vs. query rows itself, so no
+separate complete reference set is required. Columns are imputed in place, so a
+column filled earlier is available as a feature when imputing later columns.
+
+This module intentionally depends only on ``numpy`` and the package's own model
+helpers — not on :class:`TabPFNUnsupervisedModel`.
+
+Example usage:
+    ```python
+    import numpy as np
+    from tabpfn_extensions.unsupervised import simple_impute
+
+    X = np.array([[1.0, 2.0], [np.nan, 3.0], [4.0, np.nan]])
+    X_imputed = simple_impute(X)
+    ```
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+# Import TabPFN models from extensions (which handles backend compatibility)
+from tabpfn_extensions.utils import (  # type: ignore
+    TabPFNClassifier,
+    TabPFNRegressor,
+    get_max_num_classes,
+    infer_categorical_features,
+)
+
+
+def impute_column(
+    X: np.ndarray,
+    col: int,
+    model: object,
+    *,
+    classification: bool = False,
+) -> np.ndarray:
+    """Impute column ``col`` of ``X`` (``np.nan`` = missing) in place.
+
+    Uses every other column as features (feature NaNs left in — TabPFN handles
+    them), fits ``model`` on the rows where ``col`` is observed, and predicts the
+    rows where it is missing.
+
+    Parameters:
+        X: Data of shape ``(n_samples, n_features)`` with missing values as ``np.nan``.
+        col: Index of the column to impute.
+        model: A fitted-on-call TabPFN estimator (regressor, or classifier when
+            ``classification=True``).
+        classification: If True, treat the target as categorical (fit on integer
+            labels and predict class labels).
+
+    Returns:
+        np.ndarray: ``X`` with column ``col`` filled (mutated in place and returned).
+    """
+    features = [c for c in range(X.shape[1]) if c != col]
+    missing = np.isnan(X[:, col])
+
+    # context = rows where the target column is observed (real labels)
+    # query   = rows where the target column is missing
+    X_ctx, y_ctx = X[~missing][:, features], X[~missing, col]
+    X_query = X[missing][:, features]
+
+    model.fit(X_ctx, y_ctx.astype(int) if classification else y_ctx)
+    X[missing, col] = model.predict(X_query)
+    return X
+
+
+def simple_impute(
+    X: np.ndarray,
+    tabpfn_clf: object | None = None,
+    tabpfn_reg: object | None = None,
+    categorical_features: list[int] | None = None,
+) -> np.ndarray:
+    """Impute all missing values (``np.nan``) in ``X``, one column at a time.
+
+    For each column that contains missing values, fit a TabPFN model on the rows
+    where that column is observed and predict the missing rows, using all other
+    columns as features. Numerical columns use a regressor; categorical columns
+    use a classifier. The imputation is done in place across columns, so an
+    earlier-imputed column is used as a feature for later ones.
+    Colums are imputed left to right, if needed, change column order beforehand.
+
+    Parameters:
+        X: Data of shape ``(n_samples, n_features)`` with missing values encoded
+            as ``np.nan``. Converted to a float array (a copy is made; the input
+            is not modified).
+        tabpfn_reg: TabPFN regressor used for numerical columns. Defaults to
+            ``TabPFNRegressor()`` when needed.
+        tabpfn_clf: TabPFN classifier used for categorical columns. Defaults to
+            ``TabPFNClassifier()`` when needed.
+        categorical_features: Indices of categorical columns. If None, they are
+            inferred from the data.
+
+    Returns:
+        np.ndarray: A new array with all missing values imputed.
+    """
+    X = np.array(X, dtype=np.float32, copy=True)
+    n_features = X.shape[1]
+
+    categorical_features = infer_categorical_features(X, categorical_features)
+
+    for col in range(n_features):
+        if not np.isnan(X[:, col]).any():
+            continue
+
+        # A categorical column is imputed with the classifier only when one is
+        # available and it can predict that many classes; otherwise fall back to
+        # the regressor (mirrors TabPFNUnsupervisedModel's routing).
+        use_clf = col in categorical_features
+        if use_clf and tabpfn_clf is not None:
+            max_classes = get_max_num_classes(tabpfn_clf)
+            n_unique = len(np.unique(X[~np.isnan(X[:, col]), col]))
+            use_clf = max_classes is None or n_unique <= max_classes
+
+        if use_clf:
+            if tabpfn_clf is None:
+                tabpfn_clf = TabPFNClassifier()
+            impute_column(X, col, tabpfn_clf, classification=True)
+        else:
+            if tabpfn_reg is None:
+                tabpfn_reg = TabPFNRegressor()
+            impute_column(X, col, tabpfn_reg)
+
+    return X

--- a/src/tabpfn_extensions/unsupervised/simple_impute.py
+++ b/src/tabpfn_extensions/unsupervised/simple_impute.py
@@ -12,8 +12,10 @@ is observed, and predict the rows where it is missing.
 Unlike the permutation-ensembled approach in :mod:`unsupervised`, this does a
 single ``fit`` + ``predict`` per column with missing values. It is transductive:
 it takes one table and figures out reference vs. query rows itself, so no
-separate complete reference set is required. Columns are imputed in place, so a
-column filled earlier is available as a feature when imputing later columns.
+separate complete reference set is required. By default each column is imputed
+using only the original observed data, so the result is independent of column
+order; pass ``use_imputed=True`` for chained, left-to-right imputation where a
+column filled earlier feeds into later columns.
 
 This module intentionally depends only on ``numpy`` and the package's own model
 helpers — not on :class:`TabPFNUnsupervisedModel`.
@@ -87,15 +89,14 @@ def simple_impute(
     tabpfn_clf: object | None = None,
     tabpfn_reg: object | None = None,
     categorical_features: list[int] | None = None,
+    use_imputed: bool = False,
 ) -> np.ndarray:
     """Impute all missing values (``np.nan``) in ``X``, one column at a time.
 
     For each column that contains missing values, fit a TabPFN model on the rows
     where that column is observed and predict the missing rows, using all other
     columns as features. Numerical columns use a regressor; categorical columns
-    use a classifier. The imputation is done in place across columns, so an
-    earlier-imputed column is used as a feature for later ones.
-    Colums are imputed left to right, if needed, change column order beforehand.
+    use a classifier.
 
     Parameters:
         X: Data of shape ``(n_samples, n_features)`` with missing values encoded
@@ -107,6 +108,15 @@ def simple_impute(
             ``TabPFNClassifier()`` when needed.
         categorical_features: Indices of categorical columns. If None, they are
             inferred from the data.
+        use_imputed: How to treat already-imputed columns when imputing later
+            ones.
+
+            * ``False`` (default): every column is imputed using only the
+              *original* observed data as features, so the result does not depend
+              on column order.
+            * ``True``: columns are filled left to right in place, so a column
+              imputed earlier is used as a feature for later columns (chained;
+              order-dependent).
 
     Returns:
         np.ndarray: A new array with all missing values imputed.
@@ -115,6 +125,13 @@ def simple_impute(
     n_features = X.shape[1]
 
     categorical_features = infer_categorical_features(X, categorical_features)
+
+    # X stays the frozen feature source. Results are collected into X_imputed.
+    # With use_imputed=True we fill X_imputed in place so later columns see
+    # earlier imputations; with use_imputed=False we impute each column on a
+    # throwaway copy of the original and keep only that column, so the feature
+    # source never changes and the outcome is independent of column order.
+    X_imputed = X.copy()
 
     for col in range(n_features):
         if not np.isnan(X[:, col]).any():
@@ -132,10 +149,20 @@ def simple_impute(
             use_clf = max_classes is None or n_unique <= max_classes
 
         if use_clf:
-            impute_column(X, col, tabpfn_clf, classification=True)
+            model, classification = tabpfn_clf, True
         else:
             if tabpfn_reg is None:
                 tabpfn_reg = TabPFNRegressor()
-            impute_column(X, col, tabpfn_reg)
+            model, classification = tabpfn_reg, False
 
-    return X
+        if use_imputed:
+            # Chained: read features from and write into the same accumulating array.
+            impute_column(X_imputed, col, model, classification=classification)
+        else:
+            # Independent: impute on a fresh copy of the original data and keep
+            # only this column, leaving the feature source (X) untouched.
+            col_work = X.copy()
+            impute_column(col_work, col, model, classification=classification)
+            X_imputed[:, col] = col_work[:, col]
+
+    return X_imputed

--- a/src/tabpfn_extensions/unsupervised/simple_impute.py
+++ b/src/tabpfn_extensions/unsupervised/simple_impute.py
@@ -122,6 +122,10 @@ def simple_impute(
         np.ndarray: A new array with all missing values imputed.
     """
     X = np.array(X, dtype=np.float32, copy=True)
+    if X.shape[1] < 2:
+        raise ValueError(
+            "Input data X must have at least 2 columns to perform imputation."
+        )
     n_features = X.shape[1]
 
     categorical_features = infer_categorical_features(X, categorical_features)

--- a/src/tabpfn_extensions/unsupervised/simple_impute.py
+++ b/src/tabpfn_extensions/unsupervised/simple_impute.py
@@ -120,14 +120,14 @@ def simple_impute(
         # available and it can predict that many classes; otherwise fall back to
         # the regressor (mirrors TabPFNUnsupervisedModel's routing).
         use_clf = col in categorical_features
-        if use_clf and tabpfn_clf is not None:
+        if use_clf:
+            if tabpfn_clf is None:
+                tabpfn_clf = TabPFNClassifier()
             max_classes = get_max_num_classes(tabpfn_clf)
             n_unique = len(np.unique(X[~np.isnan(X[:, col]), col]))
             use_clf = max_classes is None or n_unique <= max_classes
 
         if use_clf:
-            if tabpfn_clf is None:
-                tabpfn_clf = TabPFNClassifier()
             impute_column(X, col, tabpfn_clf, classification=True)
         else:
             if tabpfn_reg is None:


### PR DESCRIPTION
## Summary
The current imputation method [`TabPFNUnsupervisedModel.impute`](https://github.com/PriorLabs/tabpfn-extensions/blob/8d11f8b8b04c0e92071e3399538255fa05074188/src/tabpfn_extensions/unsupervised/unsupervised.py#L648) is relatively involved and slow. 

This PR adds a simple lightweight alternative that simply imputes column-by-column by predicting the missing values from all the rows that contain values for the present columns. Missing values in the remaining columns are treated natively by TabPFN. It always conditions on all other features.

So far we extended the example to just include it on top of the existing.

**Discussion points**:

- [x] Shall we keep the simple method lightweight (no DAG support, no support for ordering, no temperature sampling)? If a user needs them they can implement it, but otherwise it inflates the method. I'd propose to keep it lean.
- [x] Shall we remove the old method or keep it? @noahho 
- [ ] Do we need more testing? Or any special dataset to run this through?
- [ ] So far only tested on CPU. Is that fine?

### Benefits
**Speed**: The method is faster than the existing method. The new method predicts each missing column **exactly once**. The old method iterates over columns to impute, but in each iteration temporarily imputes all the other columns first (and then discards those).   For a single permutation that is `k + (k−1) + … + 1 = k(k+1)/2` predict calls (previously-imputed columns are skipped in later iterations), and this is repeated for each of the n_permutations (default `10`) permutations.

**Accuracy**: The simple method can be more accurate because it can condition on more rows, namely all that have a value for the present column. The existing method instead has a fixed reference set that is used for all columns.

### Testing
We tested on four `sklearn` datasets (on CPU) and swiped the number of estimators (for the simple method) and the number of permutations for the existing method. On those cases the simple method is consistently faster and better (for reasons outlined above).
<img width="2227" height="1743" alt="benchmark_plot" src="https://github.com/user-attachments/assets/c8379e79-0960-4542-a39c-db743d5294e1" />