### PR TITLE
Add Dependabot cooldown and uv exclude-newer quarantine

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,10 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 3
+    # Don't propose versions released in the last 8 days, matching the main
+    # TabPFN repo (see PriorLabs/TabPFN#1114).
+    cooldown:
+      default-days: 8
 
   # GitHub Actions
   - package-ecosystem: "github-actions"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,6 +102,10 @@ dev = [
     "twine>=6.2.0",
 ]
 
+[tool.uv]
+exclude-newer = "7 days"
+exclude-newer-package = {torch = false}
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]  # Where the tests are located
 minversion = "8.0"

--- a/uv.lock
+++ b/uv.lock
@@ -21,6 +21,13 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 
+[options]
+exclude-newer = "2026-07-06T12:10:48.17113352Z"
+exclude-newer-span = "P7D"
+
+[options.exclude-newer-package]
+torch = false
+
 [[package]]
 name = "annotated-doc"
 version = "0.0.4"
@@ -3485,7 +3492,7 @@ requires-dist = [
     { name = "scikit-learn", specifier = ">=1.6.0" },
     { name = "scipy", specifier = ">=1.11.1" },
     { name = "seaborn", marker = "extra == 'interpretability'", specifier = ">=0.12.2" },
-    { name = "setuptools", marker = "extra == 'hpo'", specifier = ">=67.0.0,<82" },
+    { name = "setuptools", marker = "extra == 'hpo'", specifier = ">=67.0.0,<84" },
     { name = "shapiq", marker = "extra == 'interpretability'", specifier = ">=1.1.0" },
     { name = "tabpfn", specifier = ">=8.0.0" },
     { name = "tabpfn-common-utils", extras = ["telemetry-interactive"], specifier = ">=0.2.13" },


### PR DESCRIPTION
## What

Brings this repo in line with the main TabPFN repo's dependency-freshness protections, as requested by @oscarkey in [TabPFN#1108](https://github.com/PriorLabs/TabPFN/pull/1108#issuecomment-4957759579):

1. **Dependabot cooldown** (`dependabot.yml`): only propose versions released at least 8 days ago — same as [TabPFN#1114](https://github.com/PriorLabs/TabPFN/pull/1114). 8 days rather than 7 because Dependabot counts whole days while uv compares exact timestamps, so a 7-day cooldown could still race the quarantine below.
2. **uv quarantine** (`pyproject.toml`): `exclude-newer = "7 days"` with `exclude-newer-package = {torch = false}`, mirroring the main repo, so CI and local `uv sync` never install releases younger than 7 days. `uv.lock` is regenerated accordingly — the only unrelated hunk is a stale `requires-dist` bound for setuptools (`<82` → `<84`) that had drifted from pyproject.toml on main; no locked package versions change.

Note: Dependabot's cooldown is ignored for security updates, so those PRs can still hit the quarantine and fail CI until the fix ages 7 days — a useful signal rather than a bug.

## Verification

- `dependabot.yml` parses as valid YAML; `cooldown.default-days` is per the [Dependabot options reference](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#cooldown-) (pip is a supported ecosystem).
- `uv lock --check` passes with the new config; full resolution succeeds (171 packages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)