### PR TITLE
Add inf-imputer SHAP path for TabPFN (PRI-290)

### DIFF
--- a/changelog/344.added.md
+++ b/changelog/344.added.md
@@ -1,0 +1,1 @@
+Add `get_tabpfn_inf_explainer`, a shapiq explainer that masks absent features with `+inf` so TabPFN's native missing-value handling absorbs them (no sampling, one forward pass per coalition). Requires the model to be built with `inference_config={"PASSTHROUGH_INF": True}` (`tabpfn>=8.1.0`).

--- a/examples/interpretability/shapiq_example.py
+++ b/examples/interpretability/shapiq_example.py
@@ -1,7 +1,7 @@
 """Compute Shapley values and pairwise Shapley interactions for a TabPFN model
 using the ShapIQ library, and visualize them with shapiq's native plots.
 
-Two paradigms for "feature removal" are illustrated:
+Three paradigms for "feature removal" are illustrated:
 
   1. Imputation-based (`get_tabpfn_imputation_explainer`): masked features are
      filled by an imputer (default: baseline). The baseline imputer models
@@ -10,7 +10,13 @@ Two paradigms for "feature removal" are illustrated:
      across coalitions, so the KV-cache fast path applies — make sure
      to construct the model with `fit_mode="fit_with_cache"`.
 
-  2. Remove-and-recontextualize (`get_tabpfn_explainer`): TabPFN is re-fit on
+  2. Inf-masking (`get_tabpfn_inf_explainer`): masked features are set to
+     `+inf` and TabPFN's native missing-value handling absorbs them. No
+     sampling, one forward pass per coalition, and (like imputation) the
+     training set is fixed so the KV cache applies. Requires the model to be
+     built with `inference_config={"PASSTHROUGH_INF": True}`.
+
+  3. Remove-and-recontextualize (`get_tabpfn_explainer`): TabPFN is re-fit on
      each coalition's column subset. Does not benefit from the KV cache
      (one predict per fit).
 
@@ -29,13 +35,21 @@ housing = fetch_california_housing(as_frame=False)
 X, y, feature_names = housing.data, housing.target, list(housing.feature_names)
 
 X_train, X_test, y_train, _ = train_test_split(
-    X, y, train_size=1000, test_size=200, random_state=0,
+    X,
+    y,
+    train_size=1000,
+    test_size=200,
+    random_state=0,
 )
 x_explain = X_test[0]
 
 # Construct the regressor with the KV cache fast path. fit_mode must be set
-# BEFORE .fit().
-reg = TabPFNRegressor(fit_mode="fit_with_cache")
+# BEFORE .fit(). PASSTHROUGH_INF is required by the inf-masking explainer below
+# and is harmless for the other paths (finite inputs are unaffected).
+reg = TabPFNRegressor(
+    fit_mode="fit_with_cache",
+    inference_config={"PASSTHROUGH_INF": True},
+)
 reg.fit(X_train, y_train)
 
 # Exact enumeration for d=8 is 2**8 = 256 coalitions.
@@ -48,7 +62,7 @@ budget = 256
 imputation_explainer = tabpfn_shapiq.get_tabpfn_imputation_explainer(
     model=reg,
     data=X_train,
-    index="SV",     # plain Shapley values
+    index="SV",  # plain Shapley values
     max_order=1,
 )
 print("Computing imputation-based Shapley values...")
@@ -80,7 +94,24 @@ iv_interactions.plot_upset(feature_names=feature_names)
 
 
 # -----------------------------------------------------------------------------
-# 3. Remove-and-recontextualize (Rundel) — slower (no KV cache)
+# 3. Inf-masking explainer (uses the KV cache; TabPFN handles missingness)
+# -----------------------------------------------------------------------------
+# Masks absent features with +inf and lets TabPFN absorb them as missing. Unlike
+# the imputation explainer it does not sample from a background distribution.
+# Requires inference_config={"PASSTHROUGH_INF": True} on the model (set above).
+inf_explainer = tabpfn_shapiq.get_tabpfn_inf_explainer(
+    model=reg,
+    data=X_train,
+    index="SV",  # plain Shapley values
+    max_order=1,
+)
+print("Computing inf-masking Shapley values...")
+sv_inf = inf_explainer.explain(x=x_explain, budget=budget)
+sv_inf.plot_force(feature_names=feature_names)
+
+
+# -----------------------------------------------------------------------------
+# 4. Remove-and-recontextualize (Rundel) — slower (no KV cache)
 # -----------------------------------------------------------------------------
 # Commented out because this path is much slower than the imputation explainer
 # above, as it doesn't benefit from the KV cache: each coalition

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
     "pandas>=2.2.2",
     "scikit-learn>=1.6.0",
     "scipy>=1.11.1",
-    "tabpfn>=8.0.0",
+    "tabpfn>=8.1.0",
     "tabpfn-common-utils[telemetry-interactive]>=0.2.13",
 ]
 
@@ -104,7 +104,7 @@ dev = [
 
 [tool.uv]
 exclude-newer = "7 days"
-exclude-newer-package = {torch = false}
+exclude-newer-package = {torch = false, tabpfn = false}
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]  # Where the tests are located

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,10 +56,11 @@ source = "https://github.com/PriorLabs/tabpfn-extensions"
 
 [project.optional-dependencies]
 interpretability = [
-    # 1.1.0 is the lowest release where `imputer="baseline"` + `index="SV"` +
-    # `max_order=1` (the default config used by get_tabpfn_imputation_explainer)
-    # works without raising.
-    "shapiq>=1.1.0",
+    # 1.4.0 is the lowest release get_tabpfn_inf_explainer works with: it needs
+    # `shapiq.imputer.marginal_imputer.MarginalImputer` and
+    # `get_predict_function_and_model_type(..., class_index=...)`, both absent in
+    # <=1.2.x, and 1.3.0 is broken (unpackaged `overrides` dependency).
+    "shapiq>=1.4.0",
     "seaborn>=0.12.2",
 ]
 post_hoc_ensembles = [

--- a/src/tabpfn_extensions/interpretability/README.md
+++ b/src/tabpfn_extensions/interpretability/README.md
@@ -17,7 +17,7 @@ values and Shapley interactions. In addition, ``shapiq`` offers native support f
 TabPFN by utilizing a remove-and-recontextualize paradigm of model interpretation tailored towards
 in-context models.
 
-We expose two adapters:
+We expose three adapters:
 
 * ``get_tabpfn_explainer`` — *remove-and-recontextualize* (Rundel et al. 2024).
   TabPFN is re-fit for every coalition, so the KV cache cannot be reused
@@ -36,6 +36,25 @@ We expose two adapters:
   ```
 
   The wrapper warns at construction time if the model isn't configured this way.
+
+* ``get_tabpfn_inf_explainer`` — *inf-masking* removal. A masked feature is set to
+  ``+inf`` and TabPFN's native missing-value handling absorbs it as "missing" — no
+  sampling, one forward pass per coalition. Like the imputation path the training set
+  is fixed, so the KV cache applies. It requires the model to be built with
+  ``inference_config={"PASSTHROUGH_INF": True}`` (``tabpfn>=8.1.0``) so ``+inf`` reaches
+  the model instead of being rejected at validation; unlike ``NaN``, which TabPFN's
+  preprocessing transforms before it reaches the model, ``+inf`` is carried through:
+
+  ```python
+  clf = TabPFNClassifier(
+      fit_mode="fit_with_cache",
+      inference_config={"PASSTHROUGH_INF": True},
+  )
+  clf.fit(X_train, y_train)
+  explainer = get_tabpfn_inf_explainer(model=clf, data=X_train)
+  ```
+
+  The wrapper raises at construction time if ``PASSTHROUGH_INF`` isn't enabled.
 
 For SHAP-style plots (waterfall, beeswarm, summary, dependence) you have two options:
 

--- a/src/tabpfn_extensions/interpretability/shapiq.py
+++ b/src/tabpfn_extensions/interpretability/shapiq.py
@@ -52,6 +52,25 @@ def _require_shapiq():
     return shapiq
 
 
+def _build_tabular_explainer(shapiq, **kwargs):
+    """Construct a ``shapiq.TabularExplainer`` with ``kwargs``, silencing one warning.
+
+    shapiq emits a ``UserWarning`` when ``TabularExplainer`` is built with a
+    TabPFN model, recommending ``TabPFNExplainer`` (Rundel) instead. That advice
+    assumes the sampling-based imputers; the wrappers here deliberately use an
+    imputation/masking removal path — which, unlike Rundel, benefits from the KV
+    cache (one predict per coalition, no re-fit) — so the warning is misleading
+    and only that specific message is silenced.
+    """
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message=r".*TabPFN model with the.*shapiq\.TabularExplainer.*",
+            category=UserWarning,
+        )
+        return shapiq.TabularExplainer(**kwargs)
+
+
 @set_extension("interpretability")
 def get_tabpfn_explainer(
     model: tabpfn.TabPFNRegressor | tabpfn.TabPFNClassifier,
@@ -190,27 +209,16 @@ def get_tabpfn_imputation_explainer(
     if isinstance(data, pd.DataFrame):
         data = data.values
 
-    # shapiq emits a UserWarning when ``TabularExplainer`` is constructed with a
-    # TabPFN model, recommending ``TabPFNExplainer`` (Rundel) instead. In this
-    # wrapper the user has explicitly chosen the imputation path — precisely
-    # because Rundel cannot benefit from the KV cache (one predict per
-    # coalition fit) while imputation-based removal can. The warning is
-    # misleading here, so silence just that specific message.
-    with warnings.catch_warnings():
-        warnings.filterwarnings(
-            "ignore",
-            message=r".*TabPFN model with the.*shapiq\.TabularExplainer.*",
-            category=UserWarning,
-        )
-        return shapiq.TabularExplainer(
-            model=model,
-            data=data,
-            index=index,
-            max_order=max_order,
-            imputer=imputer,
-            class_index=class_index,
-            **kwargs,
-        )
+    return _build_tabular_explainer(
+        shapiq,
+        model=model,
+        data=data,
+        index=index,
+        max_order=max_order,
+        imputer=imputer,
+        class_index=class_index,
+        **kwargs,
+    )
 
 
 def _model_has_inf_passthrough(
@@ -368,20 +376,13 @@ def get_tabpfn_inf_explainer(
         sample_size=1,  # unused — value_function is overridden
     )
 
-    # Silence shapiq's "use TabPFNExplainer instead" warning — it assumes the
-    # sampling-based imputers and is misleading for our inf-masking path.
-    with warnings.catch_warnings():
-        warnings.filterwarnings(
-            "ignore",
-            message=r".*TabPFN model with the.*shapiq\.TabularExplainer.*",
-            category=UserWarning,
-        )
-        return shapiq.TabularExplainer(
-            model=model,
-            data=data,
-            imputer=inf_imputer,
-            index=index,
-            max_order=max_order,
-            class_index=class_index,
-            **kwargs,
-        )
+    return _build_tabular_explainer(
+        shapiq,
+        model=model,
+        data=data,
+        imputer=inf_imputer,
+        index=index,
+        max_order=max_order,
+        class_index=class_index,
+        **kwargs,
+    )

--- a/src/tabpfn_extensions/interpretability/shapiq.py
+++ b/src/tabpfn_extensions/interpretability/shapiq.py
@@ -4,7 +4,7 @@
 This module provides functions to create shapiq explainers for TabPFN models that support
 both basic Shapley values and interaction indices for more detailed model explanations.
 
-Two explanation paradigms are exposed:
+Three explanation paradigms are exposed:
 
 * :func:`get_tabpfn_explainer` — *remove-and-recontextualize* (Rundel et al. 2024).
   Re-fits TabPFN on each feature subset; cannot benefit from the KV cache
@@ -15,6 +15,14 @@ Two explanation paradigms are exposed:
   KV cache (``fit_mode="fit_with_cache"``) drastically reduces wall time. A
   runtime warning is emitted if the cache isn't enabled when this explainer
   is constructed.
+
+* :func:`get_tabpfn_inf_explainer` — *missingness-based* removal. A masked
+  feature is set to ``+inf`` and TabPFN's native missing-value handling
+  absorbs it as "missing" (no sampling, one forward pass per coalition).
+  The training set is fixed across coalitions, so it benefits from the KV
+  cache just like the imputation explainer. Requires the model to be built
+  with ``inference_config={"PASSTHROUGH_INF": True}`` (tabpfn>=8.1.0) so
+  ``+inf`` reaches the model instead of being rejected at validation.
 """
 
 from __future__ import annotations
@@ -22,15 +30,26 @@ from __future__ import annotations
 import warnings
 from typing import TYPE_CHECKING
 
+import numpy as np
 import pandas as pd
 from tabpfn_common_utils.telemetry import set_extension
 
 from tabpfn_extensions.utils import warn_if_no_kv_cache
 
 if TYPE_CHECKING:
-    import numpy as np
-
     import tabpfn
+
+
+def _require_shapiq():
+    """Import and return the ``shapiq`` package, or raise a helpful error."""
+    try:
+        import shapiq
+    except ImportError:
+        raise ImportError(
+            "Package 'shapiq' is required for model explanation. Install it with: "
+            "pip install 'tabpfn-extensions[interpretability]'",
+        ) from None
+    return shapiq
 
 
 @set_extension("interpretability")
@@ -85,15 +104,7 @@ def get_tabpfn_explainer(
         .. [3] Rundel, D., Kobialka, J., von Crailsheim, C., Feurer, M., Nagler, T., Rügamer, D. (2024). Interpretable Machine Learning for TabPFN. In: Longo, L., Lapuschkin, S., Seifert, C. (eds) Explainable Artificial Intelligence. xAI 2024. Communications in Computer and Information Science, vol 2154. Springer, Cham. https://doi.org/10.1007/978-3-031-63797-1_23
 
     """
-    # Defer the import to avoid circular imports
-    try:
-        import shapiq  # Import the main package
-        # Current version of shapiq has TabPFNExplainer in the base module
-    except ImportError:
-        raise ImportError(
-            "Package 'shapiq' is required for model explanation. "
-            "Please install it with: pip install shapiq",
-        )
+    shapiq = _require_shapiq()
 
     # make data to array if it is a pandas DataFrame
     if isinstance(data, pd.DataFrame):
@@ -171,15 +182,7 @@ def get_tabpfn_imputation_explainer(
         .. [3] Lundberg, S. M., & Lee, S. I. (2017). A Unified Approach to Interpreting Model Predictions. Advances in Neural Information Processing Systems 30 (pp. 4765--4774).
 
     """
-    # Defer the import to avoid circular imports
-    try:
-        import shapiq  # Import the main package
-        # Current version of shapiq has TabularExplainer in the base module
-    except ImportError:
-        raise ImportError(
-            "Package 'shapiq' is required for model explanation. "
-            "Please install it with: pip install shapiq",
-        )
+    shapiq = _require_shapiq()
 
     warn_if_no_kv_cache(model, context="Imputation-based SHAP")
 
@@ -205,6 +208,177 @@ def get_tabpfn_imputation_explainer(
             index=index,
             max_order=max_order,
             imputer=imputer,
+            class_index=class_index,
+            **kwargs,
+        )
+
+
+def _model_has_inf_passthrough(
+    model: tabpfn.TabPFNRegressor | tabpfn.TabPFNClassifier,
+) -> bool:
+    """Whether ``model`` is configured to pass ``+/-inf`` through to TabPFN.
+
+    Returns ``True`` only if we can positively confirm the ``PASSTHROUGH_INF``
+    inference-config flag is enabled. For estimators we can't introspect (e.g.
+    the tabpfn-client backend, which has no ``get_inference_config``) this
+    returns ``False`` — we simply can't vouch for inf support.
+    """
+    get_inference_config = getattr(model, "get_inference_config", None)
+    if get_inference_config is None:
+        return False
+    return bool(getattr(get_inference_config(), "PASSTHROUGH_INF", False))
+
+
+@set_extension("interpretability")
+def get_tabpfn_inf_explainer(
+    model: tabpfn.TabPFNRegressor | tabpfn.TabPFNClassifier,
+    data: pd.DataFrame | np.ndarray,
+    index: str = "SV",
+    max_order: int = 1,
+    class_index: int | None = None,
+    **kwargs,
+):
+    """Gets a TabularExplainer that masks missing features with ``+inf``.
+
+    When a coalition leaves a feature out, this explainer sets that feature to
+    ``+inf`` and lets TabPFN's native missing-value handling absorb it as
+    "missing" — no sampling from a background distribution, just one forward
+    pass per coalition. Since the training set never changes across
+    coalitions, this is the fastest path on TabPFN v3: construct the model
+    with ``fit_mode="fit_with_cache"`` and set
+    ``model.executor_.keep_cache_on_device = True`` after ``.fit()`` so every
+    coalition evaluation reuses one on-device KV cache.
+
+    This differs from :func:`get_tabpfn_imputation_explainer` — that one
+    *samples* the absent features from a background distribution, so their
+    values are drawn from the data. Here nothing is sampled: a masked feature
+    is genuinely missing and TabPFN decides how to handle it. ``+inf`` (rather
+    than ``NaN``) is used deliberately: ``NaN`` is transformed by TabPFN's
+    preprocessing pipeline before it reaches the model, whereas ``+inf`` is
+    carried through and handled natively as missingness.
+
+    IMPORTANT: this requires the model to be constructed with
+    ``inference_config={"PASSTHROUGH_INF": True}`` (available in
+    ``tabpfn>=8.1.0``). Without it, TabPFN rejects non-finite inputs at
+    validation and this function raises ``ValueError`` up front rather than
+    letting every coalition evaluation fail later.
+
+    Args:
+        model: The TabPFN model to explain. Must be constructed with
+            ``inference_config={"PASSTHROUGH_INF": True}``. For the v3
+            KV-cache fast path, also pass ``fit_mode="fit_with_cache"`` before
+            ``.fit(X, y)`` and set ``model.executor_.keep_cache_on_device =
+            True`` afterwards.
+
+        data: Background data. Only its shape (number of features) and a single
+            row for shapiq's compatibility check are used — it does **not**
+            drive the masking, since absent features are replaced with ``+inf``
+            rather than sampled.
+
+        index: The Shapley-style index to compute. Defaults to ``"SV"`` (plain
+            Shapley values). See shapiq docs for alternatives.
+
+        max_order: Maximum interaction order. Defaults to ``1`` (individual
+            feature attributions, equivalent to classical SHAP values).
+
+        class_index: Class to explain for classification models. Defaults to
+            ``None`` (shapiq uses class 1). Ignored for regression.
+
+        **kwargs: Passed through to ``shapiq.TabularExplainer``.
+
+    Returns:
+        shapiq.TabularExplainer: wired up with an ``+inf``-passthrough imputer.
+
+    Raises:
+        ValueError: If ``model`` can be introspected and does not have
+            ``PASSTHROUGH_INF`` enabled.
+
+    Example:
+        >>> from tabpfn import TabPFNClassifier
+        >>> from tabpfn_extensions.interpretability import shapiq as tpe_shapiq
+        >>> clf = TabPFNClassifier(
+        ...     inference_config={"PASSTHROUGH_INF": True},
+        ...     fit_mode="fit_with_cache",
+        ... )
+        >>> clf.fit(X_train, y_train)
+        >>> clf.executor_.keep_cache_on_device = True  # optional but faster
+        >>> explainer = tpe_shapiq.get_tabpfn_inf_explainer(
+        ...     model=clf, data=X_train, class_index=1
+        ... )
+        >>> iv = explainer.explain(x=X_test[0], budget=2 ** X_train.shape[1])
+    """
+    # Deferred import (kept function-local). Once the top package is confirmed
+    # present, its submodules are part of the same install and import safely.
+    shapiq = _require_shapiq()
+    from shapiq.explainer.utils import get_predict_function_and_model_type
+    from shapiq.imputer.marginal_imputer import MarginalImputer
+
+    # Fail fast: without inf passthrough, TabPFN rejects +inf at validation.
+    if not _model_has_inf_passthrough(model):
+        raise ValueError(
+            "get_tabpfn_inf_explainer masks missing features with +inf, which "
+            "requires the TabPFN model to be constructed with "
+            'inference_config={"PASSTHROUGH_INF": True} (available in '
+            "tabpfn>=8.1.0). Without it, TabPFN rejects non-finite inputs at "
+            "validation. Re-create the model, e.g. "
+            'TabPFNClassifier(inference_config={"PASSTHROUGH_INF": True}, '
+            'fit_mode="fit_with_cache"), and refit it before explaining.',
+        )
+
+    warn_if_no_kv_cache(model, context="Inf-masking SHAP")
+
+    class _InfImputer(MarginalImputer):
+        """Replace absent features with ``+inf`` instead of sampling.
+
+        ``value_function`` masks with ``+inf`` (one predict per coalition, no
+        sampling). ``calc_empty_prediction`` computes ``v(empty)`` as a single
+        ``f(inf, ..., inf)`` row instead of the base class's predict over the
+        whole background, which OOMs on large training sets (PRI-290).
+        """
+
+        def value_function(self, coalitions: np.ndarray) -> np.ndarray:
+            x_masked = np.tile(self.x, (coalitions.shape[0], 1)).astype(float)
+            x_masked[~coalitions] = np.inf
+            return self.predict(x_masked)
+
+        def calc_empty_prediction(self) -> float:
+            empty_row = np.full((1, self.n_features), np.inf)
+            empty_prediction = float(np.mean(self.predict(empty_row)))
+            self.empty_prediction = empty_prediction
+            if self.normalize:
+                self.normalization_value = empty_prediction
+            return empty_prediction
+
+    if isinstance(data, pd.DataFrame):
+        data = data.values
+
+    # Wrap the model as a plain callable so the imputer can be built before the
+    # TabularExplainer attaches its own predict function.
+    predict_fn, _ = get_predict_function_and_model_type(model, class_index=class_index)
+
+    def _callable_model(X: np.ndarray) -> np.ndarray:
+        return predict_fn(model, X)
+
+    inf_imputer = _InfImputer(
+        model=_callable_model,
+        data=data,
+        sample_size=1,  # unused — value_function is overridden
+    )
+
+    # Silence shapiq's "use TabPFNExplainer instead" warning — it assumes the
+    # sampling-based imputers and is misleading for our inf-masking path.
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message=r".*TabPFN model with the.*shapiq\.TabularExplainer.*",
+            category=UserWarning,
+        )
+        return shapiq.TabularExplainer(
+            model=model,
+            data=data,
+            imputer=inf_imputer,
+            index=index,
+            max_order=max_order,
             class_index=class_index,
             **kwargs,
         )

--- a/src/tabpfn_extensions/interpretability/shapiq.py
+++ b/src/tabpfn_extensions/interpretability/shapiq.py
@@ -333,11 +333,14 @@ def get_tabpfn_inf_explainer(
         ``value_function`` masks with ``+inf`` (one predict per coalition, no
         sampling). ``calc_empty_prediction`` computes ``v(empty)`` as a single
         ``f(inf, ..., inf)`` row instead of the base class's predict over the
-        whole background, which OOMs on large training sets (PRI-290).
+        whole background, which OOMs on large training sets.
         """
 
         def value_function(self, coalitions: np.ndarray) -> np.ndarray:
-            x_masked = np.tile(self.x, (coalitions.shape[0], 1)).astype(float)
+            x_masked = np.tile(self.x, (coalitions.shape[0], 1))
+            # int/bool arrays can't hold +inf; promote them. float and object already can.
+            if np.issubdtype(x_masked.dtype, np.integer) or x_masked.dtype == bool:
+                x_masked = x_masked.astype(float)
             x_masked[~coalitions] = np.inf
             return self.predict(x_masked)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -306,6 +306,25 @@ def classification_data(dataset_generator):
 
 
 @pytest.fixture
+def classification_data_with_text(dataset_generator):
+    """Return a classification dataset (pandas) with a string/text column.
+
+    The label depends only on the numeric features; the ``text`` column is a
+    plain string categorical for exercising non-numeric feature handling.
+    """
+    test_size = SMALL_TEST_SIZE if FAST_TEST_MODE else DEFAULT_TEST_SIZE
+    X, y = dataset_generator.generate_classification_data(
+        n_samples=test_size,
+        n_features=2,
+        n_classes=2,
+        as_pandas=True,
+    )
+    X = X.copy()
+    X["text"] = dataset_generator.rng.choice(["a", "b", "c"], size=len(X))
+    return X, y
+
+
+@pytest.fixture
 def multiclass_data(dataset_generator):
     """Return a classification dataset with 3+ classes."""
     # For multiclass data, we need more samples to ensure proper stratification

--- a/tests/test_interpretability_shapiq.py
+++ b/tests/test_interpretability_shapiq.py
@@ -1,0 +1,124 @@
+"""Tests for the shapiq interpretability adapters.
+
+Focused on ``get_tabpfn_inf_explainer`` (PRI-290), which masks absent features
+with ``+inf`` and relies on TabPFN's opt-in ``PASSTHROUGH_INF`` inference config.
+
+These are local-only: ``inference_config``/``PASSTHROUGH_INF`` is a local-tabpfn
+feature not exposed by the client backend. They run on CPU (fp32), where the
+value function is deterministic and the Shapley efficiency identity is tight —
+so we can compare the imputer's masking against hand-built masked predictions
+exactly, rather than merely asserting the pipeline "runs".
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from tabpfn_extensions.interpretability import shapiq as tpe_shapiq
+from tabpfn_extensions.utils import TabPFNClassifier
+
+pytest.importorskip("shapiq")
+
+CLASS_INDEX = 1
+
+
+@pytest.fixture
+def passthrough_clf(classification_data):
+    """A fitted classifier with +inf passthrough and the KV cache enabled."""
+    X, y = classification_data
+    clf = TabPFNClassifier(
+        device="cpu",
+        n_estimators=1,
+        fit_mode="fit_with_cache",
+        inference_config={"PASSTHROUGH_INF": True},
+    )
+    clf.fit(X, y)
+    clf.executor_.keep_cache_on_device = True
+    return clf
+
+
+def _class_predict(clf):
+    """The class-aware predict callable shapiq uses internally (logit space)."""
+    from shapiq.explainer.utils import get_predict_function_and_model_type
+
+    predict_fn, _ = get_predict_function_and_model_type(clf, class_index=CLASS_INDEX)
+    return lambda X: predict_fn(clf, np.asarray(X, dtype=float))
+
+
+@pytest.mark.local_compatible
+def test_raises_without_passthrough(classification_data):
+    """Without PASSTHROUGH_INF the wrapper fails fast with an actionable error,
+    instead of letting a cryptic validation error surface at predict time.
+    """
+    X, y = classification_data
+    clf = TabPFNClassifier(device="cpu", n_estimators=1)  # PASSTHROUGH_INF off
+    clf.fit(X, y)
+    with pytest.raises(ValueError, match="PASSTHROUGH_INF"):
+        tpe_shapiq.get_tabpfn_inf_explainer(model=clf, data=X)
+
+
+@pytest.mark.local_compatible
+def test_value_function_masks_absent_features_with_inf(
+    classification_data, passthrough_clf
+):
+    """The core behaviour: for each coalition the imputer sets exactly the
+    *absent* features to +inf, keeps the present ones at x, and feeds that to the
+    model — matching a hand-built masked prediction, batched over coalitions.
+    """
+    X, _ = classification_data
+    d = X.shape[1]
+    predict = _class_predict(passthrough_clf)
+
+    imputer = tpe_shapiq.get_tabpfn_inf_explainer(
+        model=passthrough_clf, data=X, class_index=CLASS_INDEX
+    ).imputer
+    x = X[0].astype(float)
+    imputer.fit(x)
+
+    # A partial coalition (keep features 0 and 2), the full and empty coalitions,
+    # evaluated together to also exercise batching.
+    partial = np.zeros(d, dtype=bool)
+    partial[[0, 2]] = True
+    coalitions = np.stack([partial, np.ones(d, bool), np.zeros(d, bool)])
+
+    got = imputer.value_function(coalitions)
+
+    # The imputer's masking (absent -> +inf, present -> x) must reproduce an
+    # independently hand-masked prediction, across the partial, full and empty
+    # coalitions. A wrong fill value (e.g. NaN) or masking the wrong features
+    # would make `got` diverge from `expected`.
+    expected = predict(np.stack([np.where(coal, x, np.inf) for coal in coalitions]))
+    assert got.shape == (3,)
+    assert np.allclose(got, expected, atol=1e-5)
+
+
+@pytest.mark.local_compatible
+def test_calc_empty_prediction_uses_single_all_inf_row(
+    classification_data, passthrough_clf
+):
+    """OOM fix (PRI-290): v(empty) is one all-+inf forward pass, not a predict
+    over the whole background (the base MarginalImputer behaviour that OOMs).
+    """
+    X, _ = classification_data
+    d = X.shape[1]
+    predict = _class_predict(passthrough_clf)
+    explainer = tpe_shapiq.get_tabpfn_inf_explainer(
+        model=passthrough_clf, data=X, class_index=CLASS_INDEX
+    )
+
+    calls = []
+    orig_predict = explainer.imputer.predict
+
+    def spy(arr):
+        calls.append(np.asarray(arr))
+        return orig_predict(arr)
+
+    explainer.imputer.predict = spy
+    value = explainer.imputer.calc_empty_prediction()
+
+    assert len(calls) == 1
+    row = calls[0]
+    assert row.shape == (1, d)  # a single row, not len(X)
+    assert np.isinf(row).all()  # all +inf
+    assert np.isclose(value, predict(np.full((1, d), np.inf))[0], atol=1e-5)

--- a/tests/test_interpretability_shapiq.py
+++ b/tests/test_interpretability_shapiq.py
@@ -1,7 +1,7 @@
 """Tests for the shapiq interpretability adapters.
 
-Focused on ``get_tabpfn_inf_explainer`` (PRI-290), which masks absent features
-with ``+inf`` and relies on TabPFN's opt-in ``PASSTHROUGH_INF`` inference config.
+Focused on ``get_tabpfn_inf_explainer``, which masks absent features with
+``+inf`` and relies on TabPFN's opt-in ``PASSTHROUGH_INF`` inference config.
 
 These are local-only: ``inference_config``/``PASSTHROUGH_INF`` is a local-tabpfn
 feature not exposed by the client backend. They run on CPU (fp32), where the
@@ -97,8 +97,8 @@ def test_value_function_masks_absent_features_with_inf(
 def test_calc_empty_prediction_uses_single_all_inf_row(
     classification_data, passthrough_clf
 ):
-    """OOM fix (PRI-290): v(empty) is one all-+inf forward pass, not a predict
-    over the whole background (the base MarginalImputer behaviour that OOMs).
+    """v(empty) is one all-+inf forward pass, not a predict over the whole
+    background (the base MarginalImputer behaviour that OOMs on large data).
     """
     X, _ = classification_data
     d = X.shape[1]
@@ -122,3 +122,46 @@ def test_calc_empty_prediction_uses_single_all_inf_row(
     assert row.shape == (1, d)  # a single row, not len(X)
     assert np.isinf(row).all()  # all +inf
     assert np.isclose(value, predict(np.full((1, d), np.inf))[0], atol=1e-5)
+
+
+@pytest.mark.local_compatible
+def test_inf_explainer_handles_string_column(classification_data_with_text):
+    """+inf masking works on a dataset with a string/categorical column.
+
+    Such a row is an object array, so the masked features must stay object dtype
+    for +inf to be assignable, and TabPFN absorbs the +inf as missing. Checks the
+    explainer runs end to end and that masking the string feature with +inf
+    reproduces a hand-built object-array prediction.
+    """
+    from shapiq.explainer.utils import get_predict_function_and_model_type
+
+    df, y = classification_data_with_text
+    d = df.shape[1]
+    text_col = df.columns.get_loc("text")
+    clf = TabPFNClassifier(
+        device="cpu", n_estimators=1, inference_config={"PASSTHROUGH_INF": True}
+    )
+    clf.fit(df, y)
+    predict_fn, _ = get_predict_function_and_model_type(clf, class_index=CLASS_INDEX)
+
+    explainer = tpe_shapiq.get_tabpfn_inf_explainer(
+        model=clf, data=df, class_index=CLASS_INDEX
+    )
+
+    # End-to-end run over the object-dtype array (numeric columns + a string).
+    x0 = df.iloc[0].to_numpy()
+    iv = explainer.explain(x=x0, budget=2**d)
+    sv = iv.get_n_order_values(1)
+    assert sv.shape == (d,)
+    assert np.isfinite(sv).all()
+
+    # Dropping only the string feature keeps an object array and matches a
+    # hand-built prediction with that feature replaced by +inf.
+    imputer = explainer.imputer
+    imputer.fit(x0)
+    coalition = np.ones((1, d), dtype=bool)
+    coalition[0, text_col] = False
+    got = imputer.value_function(coalition)
+    expected_row = x0.astype(object).copy()
+    expected_row[text_col] = np.inf
+    assert np.allclose(got, predict_fn(clf, expected_row.reshape(1, -1)), atol=1e-5)

--- a/uv.lock
+++ b/uv.lock
@@ -22,7 +22,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-07-07T14:25:42.800811Z"
+exclude-newer = "2026-07-08T06:46:44.53321Z"
 exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
@@ -3493,7 +3493,7 @@ requires-dist = [
     { name = "scipy", specifier = ">=1.11.1" },
     { name = "seaborn", marker = "extra == 'interpretability'", specifier = ">=0.12.2" },
     { name = "setuptools", marker = "extra == 'hpo'", specifier = ">=67.0.0,<84" },
-    { name = "shapiq", marker = "extra == 'interpretability'", specifier = ">=1.1.0" },
+    { name = "shapiq", marker = "extra == 'interpretability'", specifier = ">=1.4.0" },
     { name = "tabpfn", specifier = ">=8.1.0" },
     { name = "tabpfn-common-utils", extras = ["telemetry-interactive"], specifier = ">=0.2.13" },
     { name = "tabpfn-extensions", extras = ["interpretability", "post-hoc-ensembles", "hpo", "survival"], marker = "extra == 'all'" },

--- a/uv.lock
+++ b/uv.lock
@@ -22,10 +22,11 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-07-06T12:10:48.17113352Z"
+exclude-newer = "2026-07-07T14:25:42.800811Z"
 exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
+tabpfn = false
 torch = false
 
 [[package]]
@@ -3378,7 +3379,7 @@ wheels = [
 
 [[package]]
 name = "tabpfn"
-version = "8.0.8"
+version = "8.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "einops" },
@@ -3396,14 +3397,13 @@ dependencies = [
     { name = "scikit-learn" },
     { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "scipy", version = "1.16.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "tabpfn-common-utils" },
     { name = "torch" },
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6b/65/3e8de3115a1588c58d190a6c26aa8499303f625c6a811eb9dba42d4fa888/tabpfn-8.0.8.tar.gz", hash = "sha256:0bdbc438f2920fb98232a136ee79e01d06499f3883491704ddae332d205e7a43", size = 764626, upload-time = "2026-06-10T15:27:42.401Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d9/51/b56849eee53641a54337057dda9bb4f1a8188adf686dd822025e32b8f164/tabpfn-8.1.0.tar.gz", hash = "sha256:eab8b5b7c258cc374e4d7c1c614fea9d71d446ae271ad93c748efe92b6fdbfc1", size = 763933, upload-time = "2026-07-13T09:26:50.589Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/b5/bd2262ddf99193c440b96e4a4e1609ef02017bc030dd23e9da2d92e111fa/tabpfn-8.0.8-py3-none-any.whl", hash = "sha256:b6c945c8bf23b86f595697fcfa4ce58d84105441baf7e1313edc7865d7d29658", size = 753248, upload-time = "2026-06-10T15:27:40.466Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/da/579550955d8380d8c5d50dfb039963122798421d332c5fd9c742b9bf627a/tabpfn-8.1.0-py3-none-any.whl", hash = "sha256:127bfdecd4ecfd3054b45f5c292702ed5e4a7e3e47b6f0b989e91fc55d56d374", size = 727932, upload-time = "2026-07-13T09:26:48.92Z" },
 ]
 
 [[package]]
@@ -3494,7 +3494,7 @@ requires-dist = [
     { name = "seaborn", marker = "extra == 'interpretability'", specifier = ">=0.12.2" },
     { name = "setuptools", marker = "extra == 'hpo'", specifier = ">=67.0.0,<84" },
     { name = "shapiq", marker = "extra == 'interpretability'", specifier = ">=1.1.0" },
-    { name = "tabpfn", specifier = ">=8.0.0" },
+    { name = "tabpfn", specifier = ">=8.1.0" },
     { name = "tabpfn-common-utils", extras = ["telemetry-interactive"], specifier = ">=0.2.13" },
     { name = "tabpfn-extensions", extras = ["interpretability", "post-hoc-ensembles", "hpo", "survival"], marker = "extra == 'all'" },
     { name = "torch", specifier = ">=2.1" },


### PR DESCRIPTION
## What

Adds `get_tabpfn_inf_explainer` — a third shapiq adapter alongside `get_tabpfn_explainer` (Rundel) and `get_tabpfn_imputation_explainer`. It masks absent features with `+inf` and lets TabPFN's native missing-value handling absorb them, so no sampling is needed (one forward pass per coalition) and, like the imputation path, the training set is fixed across coalitions so the KV cache applies.

Closes PRI-290. Resurrects the NaN-imputer idea from `leo/interpretability_cleanup` (`791f13b`), but masks with **`+inf` instead of `NaN`**: unlike `NaN` — which TabPFN's preprocessing transforms before it reaches the model — `+inf` is carried through natively (RES-1538).

## Key points

- **Requires `inference_config={"PASSTHROUGH_INF": True}`** (`tabpfn>=8.1.0`). Without it TabPFN rejects `±inf` at validation, so the wrapper **raises up front** with an actionable message rather than letting a cryptic error surface at predict time.
- **OOM fix (the blocker in PRI-290):** overrides `calc_empty_prediction` to compute `v(∅) = f(inf, …, inf)` in a single forward pass, instead of the base `MarginalImputer` predicting over the *entire* background (which OOMs at large `n`, e.g. 200k×500).
- Bumps `tabpfn>=8.1.0` with a per-package `exclude-newer` cooldown opt-out so the lock can resolve it.
- Factors a shared `_require_shapiq()` import helper used by all three explainers.
- Adds an example section (`shapiq_example.py`), README docs, and tests.

## Validation

- New CPU tests (`tests/test_interpretability_shapiq.py`): fail-fast guard, value-function masking semantics (vs. an independent hand-masked prediction), and the single-all-`+inf`-row OOM fix.
- Verified end-to-end on GPU (A100): inf passthrough, KV cache, `baseline == f(inf,…,inf)`, OOM fix (1 forward pass), and Shapley efficiency matching the existing imputation explainer to ~1e-3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)