### PR TITLE
docs: add bayesian_optimization to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ pip install "tabpfn-extensions[all] @ git+https://github.com/PriorLabs/tabpfn-ex
 - **embedding**: Get TabPFN's internal dense sample embeddings
 - **tabebm**: Data augmentation using TabPFN-based Energy-Based Models
 - **pval_crt**: Statistical feature relevance testing (p-values)
+- **bayesian_optimization**: Bayesian optimization with TabPFN as the surrogate model and differentiable Expected Improvement
 - **post_hoc_ensembles** *(deprecated)*: `AutoTabPFN*` — improve performance with model combination via AutoGluon. Scheduled for removal in a future release.
 - **hpo** *(deprecated)*: `TunedTabPFN*` — automatic hyperparameter tuning for TabPFN via Hyperopt. Scheduled for removal in a future release.
 
@@ -60,7 +61,7 @@ Many TabPFN Extensions works with two TabPFN implementations:
 
 Choose the backend that fits your needs - most extensions work with either option!
 
-Exceptions to this are **post_hoc_ensembles** *(deprecated)* and **embedding**, which only work with the local `tabpfn` package.
+Exceptions to this are **post_hoc_ensembles** *(deprecated)*, **embedding**, and **bayesian_optimization**, which only work with the local `tabpfn` package.
 
 ## Documentation
 
@@ -70,6 +71,7 @@ Documentation for `tabpfn-extensions` is spread across several sources. If you a
 
 Runnable scripts and notebooks for extensions and general use cases live in the [`examples/`](https://github.com/PriorLabs/tabpfn-extensions/tree/main/examples) directory of this repository:
 
+- [`bayesian_optimization/`](https://github.com/PriorLabs/tabpfn-extensions/tree/main/examples/bayesian_optimization) — Bayesian optimization with TabPFN as the surrogate and differentiable Expected Improvement
 - [`embedding/`](https://github.com/PriorLabs/tabpfn-extensions/tree/main/examples/embedding) — access TabPFN's internal dense sample embeddings
 - [`interpretability/`](https://github.com/PriorLabs/tabpfn-extensions/tree/main/examples/interpretability) — SHAP values, partial dependence plots, feature selection
 - [`many_class/`](https://github.com/PriorLabs/tabpfn-extensions/tree/main/examples/many_class) — classification with more classes than your checkpoint supports

--- a/changelog/352.changed.md
+++ b/changelog/352.changed.md
@@ -1,0 +1,1 @@
+Document the `bayesian_optimization` extension in the README: listed under Available Extensions, linked its runnable example, and noted it requires the local `tabpfn` package.


### PR DESCRIPTION
## Summary
- List the new `bayesian_optimization` extension (merged in #343) under **Available Extensions**
- Link the runnable example under **Examples**
- Note that it requires the local `tabpfn` package (no `tabpfn-client` support) in **Backend Options**

🤖 Generated with [Claude Code](https://claude.com/claude-code)