### PR TITLE
Cap lightgbm below 4.7.0 to unblock the CI license check

### DIFF
--- a/changelog/366.changed.md
+++ b/changelog/366.changed.md
@@ -1,0 +1,1 @@
+Cap the optional `lightgbm` dependency below 4.7.0, which reports no license on PyPI and fails the CI license check.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,11 @@ interpretability = [
     # both fall back to a weaker DecisionTree. Only needed where those estimators
     # exist (shapiq>=1.6.0, i.e. Python>=3.12).
     "xgboost>=2.1.0; python_version >= '3.12'",
-    "lightgbm>=4.3.0; python_version >= '3.12'",
+    # Capped below 4.7.0: that release switched to PEP 639 license metadata and
+    # PyPI reports no license for it, so the CI license check sees an empty
+    # license and fails. Revisit once PyPI or licensecheck surfaces its MIT
+    # license again, and drop the cap.
+    "lightgbm>=4.3.0,<4.7.0; python_version >= '3.12'",
     "seaborn>=0.12.2",
 ]
 # Install scikit-survival manually if you need SurvivalTabPFN

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,10 +68,8 @@ interpretability = [
     # both fall back to a weaker DecisionTree. Only needed where those estimators
     # exist (shapiq>=1.6.0, i.e. Python>=3.12).
     "xgboost>=2.1.0; python_version >= '3.12'",
-    # Capped below 4.7.0: that release switched to PEP 639 license metadata and
-    # PyPI reports no license for it, so the CI license check sees an empty
-    # license and fails. Revisit once PyPI or licensecheck surfaces its MIT
-    # license again, and drop the cap.
+    # Capped below 4.7.0 to match the resolution-wide constraint in [tool.uv];
+    # see the note there. Worth revisiting once that cap can be dropped.
     "lightgbm>=4.3.0,<4.7.0; python_version >= '3.12'",
     "seaborn>=0.12.2",
 ]
@@ -119,6 +117,12 @@ examples = [
 ]
 
 [tool.uv]
+# lightgbm 4.7.0 switched to PEP 639 license metadata and PyPI reports no license
+# at all for that release, so the CI license check sees an empty license and fails.
+# tabpfn itself depends on lightgbm>=3.0, so the cap has to be a resolution-wide
+# constraint; bounding it in the interpretability extra alone does not reach the
+# transitive copy. Worth revisiting once PyPI reports its MIT license again.
+constraint-dependencies = ["lightgbm<4.7.0"]
 exclude-newer = "7 days"
 exclude-newer-package = {torch = false, tabpfn = false}
 

--- a/uv.lock
+++ b/uv.lock
@@ -22,7 +22,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-07-17T09:18:55.986747Z"
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
@@ -3589,7 +3589,7 @@ examples = [
 [package.metadata]
 requires-dist = [
     { name = "botorch", marker = "extra == 'bayesian-optimization'", specifier = ">=0.12.0" },
-    { name = "lightgbm", marker = "python_full_version >= '3.12' and extra == 'interpretability'", specifier = ">=4.3.0" },
+    { name = "lightgbm", marker = "python_full_version >= '3.12' and extra == 'interpretability'", specifier = ">=4.3.0,<4.7.0" },
     { name = "pandas", specifier = ">=2.2.2" },
     { name = "scikit-learn", specifier = ">=1.6.0" },
     { name = "scipy", specifier = ">=1.11.1" },

--- a/uv.lock
+++ b/uv.lock
@@ -29,6 +29,9 @@ exclude-newer-span = "P7D"
 tabpfn = false
 torch = false
 
+[manifest]
+constraints = [{ name = "lightgbm", specifier = "<4.7.0" }]
+
 [[package]]
 name = "annotated-doc"
 version = "0.0.4"


### PR DESCRIPTION
lightgbm 4.7.0 switched to PEP 639 license metadata (License-Expression instead of the License field and the OSI classifier). PyPI's JSON API reports no license at all for that release, so licensecheck sees an empty license, which is not in the --only-licenses allowlist, and the "Check for forbidden licenses" job fails.

The break is time-based, not code-based: exclude-newer = "7 days" is a rolling quarantine, and it rolled past the 2026-07-18 release of 4.7.0 between the last green run on main and today. main and every open PR fail identically.

Capping at <4.7.0 keeps the lock on 4.6.0, which still ships the MIT classifier.