### PR TITLE
Cache scikit learn datasets between CI runs.

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -60,8 +60,10 @@ jobs:
             dependency-set: highest
     runs-on: ${{ matrix.os }}
 
-    env:
-      TABPFN_MODEL_CACHE_DIR: ${{ github.workspace }}/model_cache
+    env: &data-cache-env
+      DATA_CACHE_DIR: ${{ github.workspace }}/.data-cache
+      TABPFN_MODEL_CACHE_DIR: ${{ github.workspace }}/.data-cache/tabpfn-models
+      SCIKIT_LEARN_DATA: ${{ github.workspace }}/.data-cache/sklearn
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -79,15 +81,16 @@ jobs:
       - name: Install dependencies
         run: uv sync --all-extras --group ci --resolution ${{ matrix.dependency-set }}
 
-      - name: Restore model cache
-        id: restore-model-cache
+      - &restore-data-cache
+        name: Restore data cache
+        id: restore-data-cache
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          path: ${{ github.workspace }}/model_cache
-          # This cache read will always fail as the model_cache directory is empty.
-          key: model-cache-${{ hashFiles('model_cache/**') }}
+          path: ${{ env.DATA_CACHE_DIR }}
+          # This cache read will always fail as the .data-cache directory is empty.
+          key: data-cache-${{ hashFiles('.data-cache/**') }}
           restore-keys: |
-            model-cache-
+            data-cache-
           enableCrossOsArchive: true
 
       # Download all models fails, if there is a missing model that can't be downloaded.
@@ -137,12 +140,15 @@ jobs:
           $env:FAST_TEST_MODE = 1
           uv run --no-sync pytest tests/
 
-      - name: Save model cache
-        if: github.ref == 'refs/heads/main'
+      - &save-data-cache
+        name: Save data cache
+        # Save the cache even when tests fail. This means that we save some datasets
+        # when being rate-limited, so can succeed the next time around.
+        if: always()
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          path: ${{ github.workspace }}/model_cache
-          key: model-cache-${{ hashFiles('model_cache/**') }}
+          path: ${{ env.DATA_CACHE_DIR }}
+          key: data-cache-${{ hashFiles('.data-cache/**') }}
           enableCrossOsArchive: true
 
   test_gpu:
@@ -164,8 +170,7 @@ jobs:
 
     runs-on: ubuntu-22.04-4core-gpu
 
-    env:
-      TABPFN_MODEL_CACHE_DIR: ${{ github.workspace }}/model_cache
+    env: *data-cache-env
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -183,16 +188,7 @@ jobs:
       - name: Install dependencies
         run: uv sync --all-extras --group ci --resolution ${{ matrix.dependency-set }}
 
-      - name: Restore model cache
-        id: restore-model-cache
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ${{ github.workspace }}/model_cache
-          # This cache read will always fail as the model_cache directory is empty.
-          key: model-cache-${{ hashFiles('model_cache/**') }}
-          restore-keys: |
-            model-cache-
-          enableCrossOsArchive: true
+      - *restore-data-cache
 
       # Download all models fails, if there is a missing model that can't be downloaded.
       - name: Download models from Hugging Face
@@ -210,13 +206,7 @@ jobs:
         run: |
           FAST_TEST_MODE=1 uv run --no-sync pytest tests/
 
-      - name: Save model cache
-        if: github.ref == 'refs/heads/main'
-        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ${{ github.workspace }}/model_cache
-          key: model-cache-${{ hashFiles('model_cache/**') }}
-          enableCrossOsArchive: true
+      - *save-data-cache
 
   example_smoke:
     name: Example smoke (CPU)
@@ -228,8 +218,7 @@ jobs:
     # example to completion (timeout = failure) is the job of the scheduled full
     # run; see PRI-330.
     runs-on: ubuntu-latest
-    env:
-      TABPFN_MODEL_CACHE_DIR: ${{ github.workspace }}/model_cache
+    env: *data-cache-env
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -249,15 +238,7 @@ jobs:
       - name: Install dependencies
         run: uv sync --all-extras --group examples --group ci
 
-      - name: Restore model cache
-        id: restore-model-cache
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ${{ github.workspace }}/model_cache
-          key: model-cache-${{ hashFiles('model_cache/**') }}
-          restore-keys: |
-            model-cache-
-          enableCrossOsArchive: true
+      - *restore-data-cache
 
       - name: Download models from Hugging Face
         env:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -144,7 +144,7 @@ jobs:
         name: Save data cache
         # Save the cache even when tests fail. This means that we save some datasets
         # when being rate-limited, so can succeed the next time around.
-        if: always()
+        if: ${{ !cancelled() }}
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ${{ env.DATA_CACHE_DIR }}
@@ -254,6 +254,8 @@ jobs:
         run: |
           FAST_TEST_MODE=1 uv run --no-sync pytest tests/test_examples.py \
             --run-examples -n auto
+
+      - *save-data-cache
 
   build_verify:
     name: Build wheel + sdist

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -60,10 +60,8 @@ jobs:
             dependency-set: highest
     runs-on: ${{ matrix.os }}
 
-    env: &data-cache-env
-      DATA_CACHE_DIR: ${{ github.workspace }}/.data-cache
-      TABPFN_MODEL_CACHE_DIR: ${{ github.workspace }}/.data-cache/tabpfn-models
-      SCIKIT_LEARN_DATA: ${{ github.workspace }}/.data-cache/sklearn
+    env: &cache-env
+      TABPFN_MODEL_CACHE_DIR: ${{ github.workspace }}/model_cache
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -81,20 +79,17 @@ jobs:
       - name: Install dependencies
         run: uv sync --all-extras --group ci --resolution ${{ matrix.dependency-set }}
 
-      - &restore-data-cache
-        name: Restore data cache
-        id: restore-data-cache
+      - &restore-model-cache
+        name: Restore model cache
+        id: restore-model-cache
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          path: ${{ env.DATA_CACHE_DIR }}
-          # This cache read will always fail as the .data-cache directory is empty.
-          key: data-cache-${{ hashFiles('.data-cache/**') }}
-          restore-keys: |
-            data-cache-
+          path: ${{ github.workspace }}/model_cache
+          key: model-cache-
           enableCrossOsArchive: true
 
-      # Download all models fails, if there is a missing model that can't be downloaded.
-      - name: Download models from Hugging Face
+      - &download-models
+        name: Download models from Hugging Face
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           TABPFN_TOKEN: ${{ secrets.TABPFN_TOKEN }}
@@ -140,15 +135,13 @@ jobs:
           $env:FAST_TEST_MODE = 1
           uv run --no-sync pytest tests/
 
-      - &save-data-cache
-        name: Save data cache
-        # Save the cache even when tests fail. This means that we save some datasets
-        # when being rate-limited, so can succeed the next time around.
-        if: ${{ !cancelled() }}
+      - &save-model-cache
+        name: Save model cache
+        if: github.ref == 'refs/heads/main'
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          path: ${{ env.DATA_CACHE_DIR }}
-          key: data-cache-${{ hashFiles('.data-cache/**') }}
+          path: ${{ github.workspace }}/model_cache
+          key: model-cache-${{ hashFiles('model_cache/**') }}
           enableCrossOsArchive: true
 
   test_gpu:
@@ -170,7 +163,7 @@ jobs:
 
     runs-on: ubuntu-22.04-4core-gpu
 
-    env: *data-cache-env
+    env: *cache-env
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -188,14 +181,8 @@ jobs:
       - name: Install dependencies
         run: uv sync --all-extras --group ci --resolution ${{ matrix.dependency-set }}
 
-      - *restore-data-cache
-
-      # Download all models fails, if there is a missing model that can't be downloaded.
-      - name: Download models from Hugging Face
-        env:
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
-          TABPFN_TOKEN: ${{ secrets.TABPFN_TOKEN }}
-        run: uv run --no-sync python scripts/download_all_models.py
+      - *restore-model-cache
+      - *download-models
 
       - name: Run GPU Test Suite
         env:
@@ -206,19 +193,19 @@ jobs:
         run: |
           FAST_TEST_MODE=1 uv run --no-sync pytest tests/
 
-      - *save-data-cache
+      - *save-model-cache
 
   example_smoke:
     name: Example smoke (CPU)
-    # A separate job (rather than part of test_compatibility) so the examples --
-    # which are comparatively slow -- run in parallel and don't block the normal
-    # test suite. Fast smoke gate: each example runs as a subprocess and fails
-    # only if it *errors*; one that doesn't finish within the timeout still passes,
-    # since we only assert it starts and runs without crashing. Running every
-    # example to completion (timeout = failure) is the job of the scheduled full
-    # run; see PRI-330.
+    # A separate job so that the examples, which are slow, run in parallel to the main
+    # test suite.
+    # We set FAST_TEST_MODE=1, which checks that the examples start without crashing,
+    # but does not run them to completion. test_examples_full.yml runs periodically to
+    # perform a full test.
     runs-on: ubuntu-latest
-    env: *data-cache-env
+    env:
+      TABPFN_MODEL_CACHE_DIR: ${{ github.workspace }}/model_cache
+      SCIKIT_LEARN_DATA: ${{ github.workspace }}/sklearn_data_cache
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -238,13 +225,17 @@ jobs:
       - name: Install dependencies
         run: uv sync --all-extras --group examples --group ci
 
-      - *restore-data-cache
+      - *restore-model-cache
 
-      - name: Download models from Hugging Face
-        env:
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
-          TABPFN_TOKEN: ${{ secrets.TABPFN_TOKEN }}
-        run: uv run --no-sync python scripts/download_all_models.py
+      - name: Restore sklearn data cache
+        id: restore-sklearn-data-cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ env.SCIKIT_LEARN_DATA }}
+          key: sklearn-data-examples-cache-
+          enableCrossOsArchive: true
+
+      - *download-models
 
       # -n auto runs the examples in parallel to keep wall-clock down. The
       # per-example timeout is fixed in tests/test_examples.py.
@@ -255,7 +246,14 @@ jobs:
           FAST_TEST_MODE=1 uv run --no-sync pytest tests/test_examples.py \
             --run-examples -n auto
 
-      - *save-data-cache
+      - *save-model-cache
+
+      - name: Save dataset cache
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ env.SCIKIT_LEARN_DATA }}
+          key: sklearn-data-examples-cache-${{ hashFiles('sklearn_data_cache/**') }}
+          enableCrossOsArchive: true
 
   build_verify:
     name: Build wheel + sdist

--- a/.github/workflows/test_examples_full.yml
+++ b/.github/workflows/test_examples_full.yml
@@ -25,9 +25,8 @@ jobs:
     timeout-minutes: 90
 
     env:
-      DATA_CACHE_DIR: ${{ github.workspace }}/.data-cache
-      TABPFN_MODEL_CACHE_DIR: ${{ github.workspace }}/.data-cache/tabpfn-models
-      SCIKIT_LEARN_DATA: ${{ github.workspace }}/.data-cache/sklearn
+      TABPFN_MODEL_CACHE_DIR: ${{ github.workspace }}/model_cache
+      SCIKIT_LEARN_DATA: ${{ github.workspace }}/sklearn_data_cache
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -48,15 +47,20 @@ jobs:
       - name: Install dependencies
         run: uv sync --all-extras --group examples --group ci
 
-      - name: Restore data cache
-        id: restore-data-cache
+      - name: Restore model cache
+        id: restore-model-cache
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          path: ${{ env.DATA_CACHE_DIR }}
-          # This cache read will always fail as the .data-cache directory is empty.
-          key: data-cache-${{ hashFiles('.data-cache/**') }}
-          restore-keys: |
-            data-cache-
+          path: ${{ github.workspace }}/model_cache
+          key: model-cache-
+          enableCrossOsArchive: true
+
+      - name: Restore sklearn data cache
+        id: restore-sklearn-data-cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ env.SCIKIT_LEARN_DATA }}
+          key: sklearn-data-examples-cache-
           enableCrossOsArchive: true
 
       - name: Download models from Hugging Face
@@ -81,12 +85,19 @@ jobs:
           uv run --no-sync pytest tests/test_examples.py --run-examples -v 2>&1 \
             | tee pytest_output.txt
 
-      - name: Save data cache
-        if: ${{ !cancelled() }}
+      - name: Save model cache
+        if: github.ref == 'refs/heads/main'
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          path: ${{ env.DATA_CACHE_DIR }}
-          key: data-cache-${{ hashFiles('.data-cache/**') }}
+          path: ${{ github.workspace }}/model_cache
+          key: model-cache-${{ hashFiles('model_cache/**') }}
+          enableCrossOsArchive: true
+
+      - name: Save dataset cache
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ env.SCIKIT_LEARN_DATA }}
+          key: sklearn-data-examples-cache-${{ hashFiles('sklearn_data_cache/**') }}
           enableCrossOsArchive: true
 
       # Scheduled-run failures don't notify anyone by default (GitHub only

--- a/.github/workflows/test_examples_full.yml
+++ b/.github/workflows/test_examples_full.yml
@@ -82,7 +82,7 @@ jobs:
             | tee pytest_output.txt
 
       - name: Save data cache
-        if: always()
+        if: ${{ !cancelled() }}
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ${{ env.DATA_CACHE_DIR }}

--- a/.github/workflows/test_examples_full.yml
+++ b/.github/workflows/test_examples_full.yml
@@ -25,7 +25,9 @@ jobs:
     timeout-minutes: 90
 
     env:
-      TABPFN_MODEL_CACHE_DIR: ${{ github.workspace }}/model_cache
+      DATA_CACHE_DIR: ${{ github.workspace }}/.data-cache
+      TABPFN_MODEL_CACHE_DIR: ${{ github.workspace }}/.data-cache/tabpfn-models
+      SCIKIT_LEARN_DATA: ${{ github.workspace }}/.data-cache/sklearn
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -46,15 +48,15 @@ jobs:
       - name: Install dependencies
         run: uv sync --all-extras --group examples --group ci
 
-      - name: Restore model cache
-        id: restore-model-cache
+      - name: Restore data cache
+        id: restore-data-cache
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          path: ${{ github.workspace }}/model_cache
-          # This cache read will always fail as the model_cache directory is empty.
-          key: model-cache-${{ hashFiles('model_cache/**') }}
+          path: ${{ env.DATA_CACHE_DIR }}
+          # This cache read will always fail as the .data-cache directory is empty.
+          key: data-cache-${{ hashFiles('.data-cache/**') }}
           restore-keys: |
-            model-cache-
+            data-cache-
           enableCrossOsArchive: true
 
       - name: Download models from Hugging Face
@@ -78,6 +80,14 @@ jobs:
           set -o pipefail
           uv run --no-sync pytest tests/test_examples.py --run-examples -v 2>&1 \
             | tee pytest_output.txt
+
+      - name: Save data cache
+        if: always()
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ env.DATA_CACHE_DIR }}
+          key: data-cache-${{ hashFiles('.data-cache/**') }}
+          enableCrossOsArchive: true
 
       # Scheduled-run failures don't notify anyone by default (GitHub only
       # emails whoever last edited the cron line), so track them as an issue.


### PR DESCRIPTION
This avoids openml 504s when calling `sklearn.datasets.fetch_openml()`. I create a single cache directoy to save/restore, like we use in other repos.

Also add yaml anchors to reduce repetition in the workflows.

Fixes PRI-359