### PR TITLE
fix(ci): save model cache before tests run

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -97,6 +97,13 @@ jobs:
           TABPFN_TOKEN: ${{ secrets.TABPFN_TOKEN }}
         run: uv run --no-sync python scripts/download_all_models.py
 
+      - name: Save model cache
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ github.workspace }}/model_cache
+          key: model-cache-${{ hashFiles('model_cache/**') }}
+          enableCrossOsArchive: true
+
       - name: Check for forbidden licenses
         if: runner.os == 'MacOS' && matrix.dependency-set == 'lowest-direct'
         shell: bash
@@ -125,13 +132,6 @@ jobs:
         run: |
           $env:FAST_TEST_MODE = 1
           uv run --no-sync pytest tests/
-
-      - name: Save model cache
-        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ${{ github.workspace }}/model_cache
-          key: model-cache-${{ hashFiles('model_cache/**') }}
-          enableCrossOsArchive: true
 
   test_gpu:
     name: Test on GPU
@@ -189,6 +189,13 @@ jobs:
           TABPFN_TOKEN: ${{ secrets.TABPFN_TOKEN }}
         run: uv run --no-sync python scripts/download_all_models.py
 
+      - name: Save model cache
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ github.workspace }}/model_cache
+          key: model-cache-${{ hashFiles('model_cache/**') }}
+          enableCrossOsArchive: true
+
       - name: Run GPU Test Suite
         env:
           CUDA_VISIBLE_DEVICES: "0"
@@ -197,13 +204,6 @@ jobs:
           TABPFN_EXCLUDE_DEVICES: "cpu,cpu:0,mps"
         run: |
           FAST_TEST_MODE=1 uv run --no-sync pytest tests/
-
-      - name: Save model cache
-        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ${{ github.workspace }}/model_cache
-          key: model-cache-${{ hashFiles('model_cache/**') }}
-          enableCrossOsArchive: true
 
   example_smoke:
     name: Example smoke (CPU)

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -127,7 +127,6 @@ jobs:
           uv run --no-sync pytest tests/
 
       - name: Save model cache
-        if: github.ref == 'refs/heads/main'
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ${{ github.workspace }}/model_cache
@@ -200,7 +199,6 @@ jobs:
           FAST_TEST_MODE=1 uv run --no-sync pytest tests/
 
       - name: Save model cache
-        if: github.ref == 'refs/heads/main'
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ${{ github.workspace }}/model_cache

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -97,7 +97,12 @@ jobs:
           TABPFN_TOKEN: ${{ secrets.TABPFN_TOKEN }}
         run: uv run --no-sync python scripts/download_all_models.py
 
+      # Only main-ref runs, so the entry lands in the default-branch scope that
+      # every PR can restore from. A pull_request run would write a copy scoped to
+      # refs/pull/<n>/merge, which no other PR can read and which counts against
+      # the repo's cache budget, hastening eviction of the entry PRs need.
       - name: Save model cache
+        if: github.ref == 'refs/heads/main'
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ${{ github.workspace }}/model_cache
@@ -189,7 +194,12 @@ jobs:
           TABPFN_TOKEN: ${{ secrets.TABPFN_TOKEN }}
         run: uv run --no-sync python scripts/download_all_models.py
 
+      # Only main-ref runs, so the entry lands in the default-branch scope that
+      # every PR can restore from. A pull_request run would write a copy scoped to
+      # refs/pull/<n>/merge, which no other PR can read and which counts against
+      # the repo's cache budget, hastening eviction of the entry PRs need.
       - name: Save model cache
+        if: github.ref == 'refs/heads/main'
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ${{ github.workspace }}/model_cache


### PR DESCRIPTION
**Why**
- Windows can't restore the model cache: its main-scoped entry was evicted, and the only run that rewrites it (a push to main) skips the save when the Windows tests fail — which they now do, with `0xc000001d`.
- So Windows re-downloads every checkpoint, and that fails in Dependabot and fork PRs, which get no `HF_TOKEN`/`TABPFN_TOKEN` (#385, #384).

**What**
- Move both `Save model cache` steps to directly after the download step, as TabPFN's `ci.yml` does, so a main run stores the entry even when the tests fail afterwards.
- Keep the `refs/heads/main` gate: a `pull_request` save is scoped to `refs/pull/<n>/merge`, which no other PR can restore and which costs 2.8GB per OS against the repo's cache budget.

Merging does not repopulate anything by itself — a `workflow_dispatch` on main after merge writes the three per-OS entries back.
