### PR TITLE
fix(unsupervised): accept array logits in outlier detection

### DIFF
--- a/changelog/390.fixed.md
+++ b/changelog/390.fixed.md
@@ -1,0 +1,1 @@
+Outlier detection no longer fails with `'numpy.ndarray' object has no attribute 'clone'` when the unsupervised model runs on the TabPFN client.

--- a/src/tabpfn_extensions/unsupervised/unsupervised.py
+++ b/src/tabpfn_extensions/unsupervised/unsupervised.py
@@ -765,13 +765,18 @@ class TabPFNUnsupervisedModel(BaseEstimator):
                 log_pred = torch.log(pred)
             else:
                 pred = model.predict(X_predict, output_type="full")
+                # Proper tensor construction to avoid warnings
                 logits = pred["logits"]
-                logits_tensor = logits.clone().detach()
+                logits_tensor = (
+                    logits.clone().detach()
+                    if torch.is_tensor(logits)
+                    else torch.as_tensor(logits)
+                )
                 # Match logits dtype/device: MPS rejects float64, and sklearn
                 # inputs arrive as float64, so cast before moving to the device.
                 y_tensor = y_predict.detach().to(
-                    dtype=logits.dtype,
-                    device=logits.device,
+                    dtype=logits_tensor.dtype,
+                    device=logits_tensor.device,
                 )
                 # criterion.forward returns the NLL, so -forward is log p_θ directly.
                 log_pred = (

--- a/tests/test_unsupervised.py
+++ b/tests/test_unsupervised.py
@@ -52,3 +52,40 @@ def test_generate_synthetic_data_categorical(monkeypatch):
 
     assert isinstance(synthetic_X, torch.Tensor)
     assert synthetic_X.shape == (n_samples, X.shape[1])
+
+
+@pytest.mark.client_compatible
+@pytest.mark.local_compatible
+def test_outliers_accepts_array_logits(monkeypatch):
+    """`logits` is a tensor from the local package and an array from the client."""
+    from tabpfn.regressor import FullSupportBarDistribution
+
+    n_rows, n_features, n_bars = 6, 2, 8
+    # float64 throughout, as the client's own criterion and logits are.
+    criterion = FullSupportBarDistribution(
+        borders=torch.linspace(-3.0, 3.0, n_bars + 1, dtype=torch.float64)
+    )
+
+    class ArrayLogitsRegressor:
+        def predict(self, X, output_type):
+            assert output_type == "full"
+            return {
+                "logits": np.zeros((len(X), n_bars)),
+                "criterion": criterion,
+            }
+
+    X = torch.randn(n_rows, n_features)
+    model = unsupervised.TabPFNUnsupervisedModel(
+        tabpfn_clf=None, tabpfn_reg=ArrayLogitsRegressor()
+    )
+    model.X_ = X
+
+    def density(X_predict, _X_fit, _conditional_idx, column_idx):
+        return model.tabpfn_reg, X_predict, X_predict[:, column_idx]
+
+    monkeypatch.setattr(model, "density_", density)
+
+    log_p = model.outliers_single_permutation_(X, feature_permutation=[0, 1])
+
+    assert log_p.shape == (n_rows,)
+    assert torch.isfinite(log_p).all()


### PR DESCRIPTION
TL;DR: matches other call sites. this is for tabpfn-client compatibility which can only return np.array, we need to support both here.
https://prior-labs.slack.com/archives/C09F8DP5K2S/p1787843262502949

<details>
<summary>Claude generated description</summary>

`TabPFNUnsupervisedModel.outliers()` fails on the client backend:

```
AttributeError: 'numpy.ndarray' object has no attribute 'clone'
```

`outliers_single_permutation_` calls `pred["logits"].clone()`, which holds only
for the local package — the local regressor types `logits` as a `torch.Tensor`,
the client returns a numpy array. The sibling call site in
`sample_from_model_prediction_` already handles both, so this mirrors it and
takes `dtype`/`device` from the converted tensor rather than the raw value.

Found by running the TabPFN demo notebook end to end against both backends; the
outlier-detection cell is the first place the difference bites.

The new test stubs the regressor, so it needs no credentials and no network.
Reverting the one-line fix turns it red with the `AttributeError` above.

</details>
