### PR TITLE
fix(interpretability): allow inf-masking SHAP on the remote backends

### DIFF
--- a/changelog/391.fixed.md
+++ b/changelog/391.fixed.md
@@ -1,0 +1,1 @@
+`get_tabpfn_inf_explainer` now works with the remote backends: a model built with `inference_config={"PASSTHROUGH_INF": True}` is accepted instead of being rejected as unsupported, so inf-masking SHAP is no longer limited to local models.

--- a/src/tabpfn_extensions/interpretability/README.md
+++ b/src/tabpfn_extensions/interpretability/README.md
@@ -83,7 +83,9 @@ We expose three adapters:
   is fixed, so the KV cache applies. It requires the model to be built with
   ``inference_config={"PASSTHROUGH_INF": True}`` (``tabpfn>=8.1.0``) so ``+inf`` reaches
   the model instead of being rejected at validation; unlike ``NaN``, which TabPFN's
-  preprocessing transforms before it reaches the model, ``+inf`` is carried through:
+  preprocessing transforms before it reaches the model, ``+inf`` is carried through.
+  This works with a local model and with the remote backends, which forward the flag
+  to the TabPFN they run:
 
   ```python
   clf = TabPFNClassifier(

--- a/src/tabpfn_extensions/interpretability/shapiq.py
+++ b/src/tabpfn_extensions/interpretability/shapiq.py
@@ -351,14 +351,16 @@ def _model_has_inf_passthrough(
     """Whether ``model`` is configured to pass ``+/-inf`` through to TabPFN.
 
     Returns ``True`` only if we can positively confirm the ``PASSTHROUGH_INF``
-    inference-config flag is enabled. For estimators we can't introspect (e.g.
-    the tabpfn-client backend, which has no ``get_inference_config``) this
-    returns ``False`` — we simply can't vouch for inf support.
+    inference-config flag is enabled, from either of the two places a backend
+    keeps it: a local model resolves it into ``get_inference_config()``, while
+    a remote one forwards the ``inference_config`` constructor argument to the
+    server, where the flag takes effect exactly as it does locally.
     """
     get_inference_config = getattr(model, "get_inference_config", None)
-    if get_inference_config is None:
-        return False
-    return bool(getattr(get_inference_config(), "PASSTHROUGH_INF", False))
+    if get_inference_config is not None:
+        return bool(getattr(get_inference_config(), "PASSTHROUGH_INF", False))
+    config = getattr(model, "inference_config", None)
+    return bool(isinstance(config, dict) and config.get("PASSTHROUGH_INF"))
 
 
 @set_extension("interpretability")
@@ -395,7 +397,8 @@ def get_tabpfn_inf_explainer(
     ``inference_config={"PASSTHROUGH_INF": True}`` (available in
     ``tabpfn>=8.1.0``). Without it, TabPFN rejects non-finite inputs at
     validation and this function raises ``ValueError`` up front rather than
-    letting every coalition evaluation fail later.
+    letting every coalition evaluation fail later. The remote backends forward
+    the flag to the TabPFN they run, so this path works there too.
 
     Args:
         model: The TabPFN model to explain. Must be constructed with

--- a/tests/test_interpretability_shapiq.py
+++ b/tests/test_interpretability_shapiq.py
@@ -3,14 +3,18 @@
 Focused on ``get_tabpfn_inf_explainer``, which masks absent features with
 ``+inf`` and relies on TabPFN's opt-in ``PASSTHROUGH_INF`` inference config.
 
-These are local-only: ``inference_config``/``PASSTHROUGH_INF`` is a local-tabpfn
-feature not exposed by the client backend. They run on CPU (fp32), where the
+The end-to-end cases are local-only, not because the feature is: the remote
+backends forward ``inference_config``/``PASSTHROUGH_INF`` to the TabPFN they
+run, and ``TestInfPassthroughDetection`` covers them with stubs. They run on
+CPU (fp32), where the
 value function is deterministic and the Shapley efficiency identity is tight —
 so we can compare the imputer's masking against hand-built masked predictions
 exactly, rather than merely asserting the pipeline "runs".
 """
 
 from __future__ import annotations
+
+from typing import ClassVar
 
 import numpy as np
 import pytest
@@ -165,3 +169,58 @@ def test_inf_explainer_handles_string_column(classification_data_with_text):
     expected_row = x0.astype(object).copy()
     expected_row[text_col] = np.inf
     assert np.allclose(got, predict_fn(clf, expected_row.reshape(1, -1)), atol=1e-5)
+
+
+class TestInfPassthroughDetection:
+    """Which backends may use the +inf masking path.
+
+    The flag lives in one of two places: a local model resolves it into
+    ``get_inference_config()``, while a remote backend only forwards the
+    ``inference_config`` constructor argument. Stubs stand in for the client
+    estimators, which are not a test dependency here.
+    """
+
+    class _Remote:
+        """Shaped like any tabpfn-client estimator: no resolvable config."""
+
+        def __init__(self, inference_config=None):
+            self.inference_config = inference_config
+
+    @pytest.mark.local_compatible
+    @pytest.mark.client_compatible
+    def test_remote_backend_with_the_flag_is_accepted(self):
+        """Both the managed API and a self-hosted endpoint honour the flag."""
+        model = self._Remote(inference_config={"PASSTHROUGH_INF": True})
+        assert tpe_shapiq._model_has_inf_passthrough(model)
+
+    @pytest.mark.local_compatible
+    @pytest.mark.client_compatible
+    def test_remote_backend_without_the_flag_is_rejected(self):
+        assert not tpe_shapiq._model_has_inf_passthrough(self._Remote())
+        assert not tpe_shapiq._model_has_inf_passthrough(
+            self._Remote(inference_config={"PASSTHROUGH_INF": False}),
+        )
+
+    @pytest.mark.local_compatible
+    @pytest.mark.client_compatible
+    def test_remote_backend_without_the_flag_raises(self, classification_data):
+        X, _ = classification_data
+        with pytest.raises(ValueError, match="PASSTHROUGH_INF"):
+            tpe_shapiq.get_tabpfn_inf_explainer(model=self._Remote(), data=X)
+
+    @pytest.mark.local_compatible
+    @pytest.mark.client_compatible
+    def test_local_model_still_uses_its_resolved_config(self):
+        """A local model's resolved config wins; its raw argument is not read."""
+
+        class _Local:
+            inference_config: ClassVar[dict] = {"PASSTHROUGH_INF": True}
+
+            def __init__(self, *, resolved: bool):
+                self._resolved = resolved
+
+            def get_inference_config(self):
+                return type("Cfg", (), {"PASSTHROUGH_INF": self._resolved})()
+
+        assert tpe_shapiq._model_has_inf_passthrough(_Local(resolved=True))
+        assert not tpe_shapiq._model_has_inf_passthrough(_Local(resolved=False))


### PR DESCRIPTION
## Changes

- **The guard refused every remote backend.** `_model_has_inf_passthrough` read only `get_inference_config()`, which no client estimator has, so `get_tabpfn_inf_explainer` rejected configurations that work. The premise that `PASSTHROUGH_INF` is local-only is wrong: `inference_config` is a field both the managed API and a self-hosted container accept, and each forwards it to the TabPFN it runs.
- **It now reads either place the flag can live** — a local model's resolved config as before, or the raw `inference_config` argument otherwise. A local model's resolved config still wins, which a test pins.
- **Both backends were tested, not assumed.** `+inf` without the flag is rejected either way (container 500, API `422 Input X contains infinity`); with it both predict normally, and the API's output moves away from the finite baseline, so the masking reaches the model.
- **Docs and tests corrected** — the path was documented as local-only.
- Self-hosted JSON payloads additionally need the hosted estimator's non-finite serialization fix, without which `+inf` never leaves the client. The managed backend uploads Parquet and is unaffected.

## Reviewer notes

- Depends on PriorLabs/tabpfn-client#372 for the self-hosted path; merge that first. The managed API path works against released tabpfn-client.
- New tests use stubs, since `tabpfn-client` is not a test dependency here. They are currently the only tests in this file that run without local model weights.
- Suite on this branch: 53 passed vs 49 on `main`, with the same 51 pre-existing failures (`TabPFNLicenseError` — no local weights in this environment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AsHuhQhqWz3EkVVtPbdBBa