### PR TITLE
fix(utils): stop telling endpoint users their backend cannot cache

### DIFF
--- a/changelog/393.fixed.md
+++ b/changelog/393.fixed.md
@@ -1,0 +1,1 @@
+Support the KV cache advice for endpoint-backed models: a self-hosted, SageMaker or Foundry estimator is no longer told its backend cannot cache, and is instead pointed at `use_kv_cache=True` when the cache is off.

--- a/src/tabpfn_extensions/utils.py
+++ b/src/tabpfn_extensions/utils.py
@@ -38,7 +38,9 @@ def warn_if_no_kv_cache(model: Any, *, context: str = "This operation") -> None:
     set runs on every predict and these extensions can be 10-100x slower
     than necessary.
 
-    Two conditions need to hold for the cache fast path:
+    What has to hold depends on the backend. An endpoint-backed estimator
+    (self-hosted container, SageMaker, Foundry) needs ``use_kv_cache=True``,
+    which is the only condition. A local model needs both:
         1. ``model`` was constructed with ``fit_mode="fit_with_cache"``
            (a constructor argument, must be set BEFORE ``.fit()``).
         2. ``model.executor_.keep_cache_on_device`` is ``True`` (set AFTER
@@ -54,12 +56,28 @@ def warn_if_no_kv_cache(model: Any, *, context: str = "This operation") -> None:
             SHAP"``, ``"Sequential feature selection"``). Defaults to a
             generic ``"This operation"``.
     """
-    # tabpfn-client doesn't expose fit_mode and doesn't (yet) support the KV
-    # cache — recommend switching to the local tabpfn package instead of
-    # firing the generic "set fit_mode='fit_with_cache'" message that would
-    # TypeError on the client. Walk the MRO because tabpfn-extensions wraps
-    # the client base classes in tabpfn_extensions.utils, so the *immediate*
-    # class' __module__ is "tabpfn_extensions.utils" and won't match.
+    # The endpoint-backed backends (self-hosted container, SageMaker, Foundry)
+    # do support the cache, through a `use_kv_cache` constructor flag. Their
+    # classes live under tabpfn_client, so this has to be checked before the
+    # MRO test below, which would otherwise call them unsupported.
+    if hasattr(model, "use_kv_cache"):
+        if not model.use_kv_cache:
+            warnings.warn(
+                f"{context} issues many predictions against a single fit, but "
+                "this estimator was built without `use_kv_cache=True`, so the "
+                "endpoint re-fits on every call. Pass `use_kv_cache=True` to "
+                "reuse the fitted model between predictions.",
+                UserWarning,
+                stacklevel=3,
+            )
+        return
+
+    # The managed API backend has no endpoint-side cache to reuse, and doesn't
+    # expose fit_mode — recommend the local package rather than firing the
+    # generic "set fit_mode='fit_with_cache'" message, which would TypeError on
+    # it. Walk the MRO because tabpfn-extensions wraps the client base classes
+    # in tabpfn_extensions.utils, so the *immediate* class' __module__ is
+    # "tabpfn_extensions.utils" and won't match.
     mro_modules = (getattr(cls, "__module__", "") for cls in type(model).__mro__)
     if any("tabpfn_client" in m for m in mro_modules):
         warnings.warn(

--- a/tests/test_kv_cache_warning.py
+++ b/tests/test_kv_cache_warning.py
@@ -1,0 +1,83 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+#  Licensed under the Apache License, Version 2.0
+"""Tests for `warn_if_no_kv_cache` across the backends.
+
+The endpoint-backed estimators (self-hosted container, SageMaker, Foundry)
+reuse a fitted model when built with `use_kv_cache=True`; the managed API
+backend has no endpoint-side cache. Stubs stand in for the client estimators,
+which are not a test dependency here.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import pytest
+
+from tabpfn_extensions.utils import warn_if_no_kv_cache
+
+
+def _warnings_from(model) -> list[str]:
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        warn_if_no_kv_cache(model, context="SHAP")
+    return [str(w.message) for w in caught]
+
+
+class _Endpoint:
+    """Shaped like the endpoint-backed tabpfn-client estimators."""
+
+    __module__ = "tabpfn_client.hosted.estimator"
+
+    def __init__(self, *, use_kv_cache: bool):
+        self.use_kv_cache = use_kv_cache
+
+
+class _Managed:
+    """Shaped like the managed tabpfn-client estimator: no endpoint cache."""
+
+    __module__ = "tabpfn_client.estimator"
+
+
+@pytest.mark.local_compatible
+@pytest.mark.client_compatible
+def test_endpoint_backend_with_the_cache_is_silent():
+    assert _warnings_from(_Endpoint(use_kv_cache=True)) == []
+
+
+@pytest.mark.local_compatible
+@pytest.mark.client_compatible
+def test_endpoint_backend_without_the_cache_points_at_the_flag():
+    (message,) = _warnings_from(_Endpoint(use_kv_cache=False))
+    assert "use_kv_cache=True" in message
+    # The old advice was to abandon the endpoint for a local install.
+    assert "pip install tabpfn" not in message
+
+
+@pytest.mark.local_compatible
+@pytest.mark.client_compatible
+def test_managed_backend_still_recommends_the_local_package():
+    (message,) = _warnings_from(_Managed())
+    assert "pip install tabpfn" in message
+
+
+@pytest.mark.local_compatible
+@pytest.mark.client_compatible
+def test_local_model_paths_are_unchanged():
+    class _Local:
+        fit_mode = "fit_preprocessors"
+
+    (message,) = _warnings_from(_Local())
+    assert "fit_with_cache" in message
+
+    class _Cached:
+        fit_mode = "fit_with_cache"
+        executor_ = type("E", (), {"keep_cache_on_device": True})()
+
+    assert _warnings_from(_Cached()) == []
+
+
+@pytest.mark.local_compatible
+@pytest.mark.client_compatible
+def test_unknown_estimator_is_left_alone():
+    assert _warnings_from(object()) == []


### PR DESCRIPTION
## Changes

- **The warning was wrong for every endpoint-backed estimator.** `warn_if_no_kv_cache` decided by matching `tabpfn_client` anywhere in the MRO, so a self-hosted container, SageMaker or Foundry model was told the backend "does not currently support" the KV cache and advised to `pip install tabpfn` — the opposite of what an on-prem user wants to hear. Since tabpfn-client 0.5.1 those backends reuse a fitted model via `use_kv_cache=True`, so the claim is simply false.
- **`use_kv_cache` is now checked first**, before the MRO test that would otherwise call those backends unsupported. They warn only when the cache is genuinely off, and the message names the flag that fixes it instead of recommending a different install.
- **Everything else keeps its current behaviour**: the managed API backend has no endpoint-side cache and keeps its original advice, local models keep both the `fit_mode` and `keep_cache_on_device` checks, and an older tabpfn-client without the flag still gets the old message — which is correct for it.
- **Tests** covering all five paths, using stubs since `tabpfn-client` is not a test dependency here.

## Reviewer notes

Verified against a self-hosted container on tabpfn-client 0.5.1 / tabpfn-extensions 0.6.1:

```
use_kv_cache=True  -> 0 warnings
use_kv_cache=False -> 1 warning: "...built without `use_kv_cache=True`, so the
                       endpoint re-fits on every call..."
```

This came out of a customer asking why they were being told to install local tabpfn while running our container. With #391 and PriorLabs/tabpfn-client#372 released, that warning was the last thing still pointing them the wrong way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018nzk1rixwf3tDaPeMSyBCX